### PR TITLE
DX: clearer errors, new human output, strict mode, shared pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ npm run generate:previews
 ```
 
 ### Test Coverage
-- Flowchart: [19 valid](./test-fixtures/flowchart/VALID_DIAGRAMS.md) • [14 invalid](./test-fixtures/flowchart/INVALID_DIAGRAMS.md)
-- Pie: [2 valid](./test-fixtures/pie/VALID_DIAGRAMS.md) • [6 invalid](./test-fixtures/pie/INVALID_DIAGRAMS.md)
+- Flowchart: [20 valid](./test-fixtures/flowchart/VALID_DIAGRAMS.md) • [15 invalid](./test-fixtures/flowchart/INVALID_DIAGRAMS.md)
+- Pie: [4 valid](./test-fixtures/pie/VALID_DIAGRAMS.md) • [6 invalid](./test-fixtures/pie/INVALID_DIAGRAMS.md)
 - 100% accuracy against mermaid-cli on fixtures
 
 ## Diagram Type Coverage (Mermaid vs mermaid-lint)
@@ -98,6 +98,19 @@ Notes
 ## Error Codes
 
 Diagnostics include stable error codes and hints for quick fixes. See the full list in [docs/errors.md](./docs/errors.md).
+
+### CLI Output Formats
+
+- Human (default): codes, hints, and an inline codeframe pointing at the exact location.
+- JSON: machine-readable report for editors/CI.
+
+```bash
+# Human (default)
+npx mermaid-lint diagram.mmd
+
+# JSON
+npx mermaid-lint --format json diagram.mmd
+```
 
 ## CI/CD Integration
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ npx mermaid-lint --format json diagram.mmd
 npx mermaid-lint --format rust diagram.mmd   # treated as human
 ```
 
+### Strict Mode
+
+Enable strict mode to require quoted labels inside shapes (e.g., `[ ... ]`, `{ ... }`, `( ... )`).
+
+```bash
+npx mermaid-lint --strict diagram.mmd
+```
+
+In strict mode, unquoted labels are flagged with `FL-STRICT-LABEL-QUOTES-REQUIRED`. Use double quotes and `&quot;` for inner quotes.
+
 ## CI/CD Integration
 
 ### GitHub Actions

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Diagnostics include stable error codes and hints for quick fixes. See the full l
 
 ### CLI Output Formats
 
-- Human (default): codes, hints, and an inline codeframe pointing at the exact location.
+- Human (default): caret-underlined snippet style with codes, hints, and precise spans.
 - JSON: machine-readable report for editors/CI.
 
 ```bash
@@ -110,6 +110,9 @@ npx mermaid-lint diagram.mmd
 
 # JSON
 npx mermaid-lint --format json diagram.mmd
+
+# Alias (still works):
+npx mermaid-lint --format rust diagram.mmd   # treated as human
 ```
 
 ## CI/CD Integration

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -44,13 +44,77 @@ Clear, actionable diagnostics aligned with mermaid-cli behavior. Each error incl
       A['She said "Hello"'] --> B
     ```
 
+- FL-DIR-MISSING
+  - When: Diagram header lacks a direction after `flowchart`/`graph`.
+  - Message: "Missing direction after diagram header. Use TD, TB, BT, RL, or LR."
+  - Hint: "Example: 'flowchart TD' for top-down layout."
+
+- FL-DIR-INVALID
+  - When: Invalid direction token (e.g., `flowchart XY`).
+  - Message: "Invalid direction 'XY'. Use one of: TD, TB, BT, RL, LR."
+  - Hint: "Try 'TD' (top-down) or 'LR' (left-to-right)."
+
+- FL-LINK-MISSING
+  - When: Two nodes appear on the same line without a connecting arrow.
+  - Message: "Two nodes on one line must be connected with an arrow before 'X'."
+  - Hint: "Insert --> between nodes, e.g., A --> B."
+
+- FL-NODE-UNCLOSED-BRACKET
+  - When: A node shape opens but is not properly closed (e.g., `[`, `(`, `{`, `[[`, `((`).
+  - Message: Clarifies which bracket is unclosed and what to add.
+  - Hint: Example-specific (e.g., `A[Label] --> B`).
+
+- FL-NODE-MIXED-BRACKETS
+  - When: Opening and closing brackets don't match (e.g., `(text]`).
+  - Message: "Mismatched brackets: opened '(' but closed with ']'."
+  - Hint: "Close with ')' or change the opening bracket to '['."
+
+- FL-CLASS-MALFORMED
+  - When: `class` statement is missing node ids or the class name.
+  - Message: "Invalid class statement. Provide node id(s) then a class name."
+  - Hint: "Example: class A,B important"
+
+- FL-SUBGRAPH-MISSING-HEADER
+  - When: `subgraph` keyword is not followed by an ID or `[Title]`.
+  - Message: "Subgraph header is missing. Add an ID or a [Title] after the keyword."
+  - Hint: "Example: subgraph API [API Layer]"
+
+- FL-END-WITHOUT-SUBGRAPH
+  - When: `end` appears without a matching `subgraph`.
+  - Message: "'end' without a matching 'subgraph'."
+  - Hint: "Remove this end or add a subgraph above."
+
 ## Pie (PI-*)
 
-Currently, pie charts are validated for header and basic syntax via the parser. Mermaid is permissive (e.g., colon is optional, labels may be loosely formatted), so no pie-specific error codes are emitted yet. The infrastructure is ready to add codes if stricter or optional rules are introduced.
+- PI-LABEL-REQUIRES-QUOTES
+  - When: Slice label is missing quotes (single or double).
+  - Message: "Slice labels must be quoted (single or double quotes)."
+  - Hint: "Example: \"Dogs\" : 10"
+
+- PI-MISSING-COLON
+  - When: Missing colon between slice label and number.
+  - Message: "Missing colon between slice label and value."
+  - Hint: "Use: \"Label\" : 10"
+
+- PI-MISSING-NUMBER
+  - When: No numeric value after the colon.
+  - Message: "Missing numeric value after colon."
+  - Hint: "Use a number like 10 or 42.5"
+
+- PI-QUOTE-UNCLOSED
+  - When: A slice label starts with a quote but is not closed.
+  - Message: "Unclosed quote in slice label."
+  - Hint: "Close the quote: \"Dogs\" : 10"
+
+## General (GEN-*)
+
+- GEN-HEADER-INVALID
+  - When: The file does not start with a known Mermaid diagram header.
+  - Message: "Diagram must start with \"graph\", \"flowchart\", or \"pie\""
+  - Hint: "Start your diagram with e.g. \"flowchart TD\" or \"pie\"."
 
 ## Notes
 
 - Codes are stable and intended for CI tooling and editor integrations.
 - Hints suggest the most typical fix while preserving Mermaid compatibility.
 - Some best-practice advisories (style-only) may be added as warnings under opt-in rule sets in the future.
-

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -44,6 +44,16 @@ Clear, actionable diagnostics aligned with mermaid-cli behavior. Each error incl
       A["She said &quot;Hello&quot;"] --> B
     ```
 
+- FL-LABEL-QUOTE-IN-UNQUOTED
+  - When: A double quote appears inside an unquoted label (e.g., within `[...]`).
+  - Message: "Double quotes inside an unquoted label are not allowed. Wrap the entire label in quotes or use &quot;."
+  - Hint: "Example: A[\"Calls logger.debug(&quot;message&quot;, data)\"]"
+  - Example (fixed):
+    ```mermaid
+    flowchart TD
+      A["Calls logger.debug(&quot;message&quot;, data)"] --> B
+    ```
+
 Tip: quoting inside labels
 - When you need double quotes inside a double‑quoted label, use the HTML entity `&quot;` instead of a backslash.
   - Correct: `A["He said &quot;Hi&quot;"]`

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -133,3 +133,7 @@ Tip: quoting inside labels
 - Codes are stable and intended for CI tooling and editor integrations.
 - Hints suggest the most typical fix while preserving Mermaid compatibility.
 - Some best-practice advisories (style-only) may be added as warnings under opt-in rule sets in the future.
+- FL-STRICT-LABEL-QUOTES-REQUIRED
+  - When: Strict mode is enabled and a node label is not quoted.
+  - Message: "Strict mode: Node label must be quoted (use double quotes and &quot; inside)."
+  - Hint: "Example: A[\"Label with &quot;quotes&quot; and (parens)\"]"

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -26,22 +26,22 @@ Clear, actionable diagnostics aligned with mermaid-cli behavior. Each error incl
 
 - FL-LABEL-ESCAPED-QUOTE
   - When: Backslash-escaped quotes appear inside a node label (Mermaid does not support `\"`).
-  - Message: "Escaped quotes (\") in node labels are not supported by Mermaid. Use &quot; or switch to single quotes."
-  - Hint: "Prefer \"He said &quot;Hi&quot;\" or use single quotes around the label."
-  - Example:
+  - Message: "Escaped quotes (\") in node labels are not supported by Mermaid. Use &quot; instead."
+  - Hint: "Prefer \"He said &quot;Hi&quot;\"."
+  - Example (fixed):
     ```mermaid
     flowchart LR
-      A["He said \"Hi\""] --> B
+      A["He said &quot;Hi&quot;"] --> B
     ```
 
 - FL-LABEL-DOUBLE-IN-SINGLE
   - When: A single-quoted label contains an unescaped double quote.
-  - Message: "Double quotes inside a single-quoted label are not supported by Mermaid. Use double-quoted label or replace \" with &quot;."
-  - Hint: "Change to \"She said \\\"Hello\\\"\" or replace inner \" with &quot;."
-  - Example:
+  - Message: "Double quotes inside a single-quoted label are not supported by Mermaid. Replace inner \" with &quot; or use a double-quoted label with &quot;."
+  - Hint: "Change to \"She said &quot;Hello&quot;\" or replace inner \" with &quot;."
+  - Example (fixed):
     ```mermaid
     flowchart LR
-      A['She said "Hello"'] --> B
+      A["She said &quot;Hello&quot;"] --> B
     ```
 
 - FL-DIR-MISSING

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -44,6 +44,11 @@ Clear, actionable diagnostics aligned with mermaid-cli behavior. Each error incl
       A["She said &quot;Hello&quot;"] --> B
     ```
 
+Tip: quoting inside labels
+- When you need double quotes inside a double‑quoted label, use the HTML entity `&quot;` instead of a backslash.
+  - Correct: `A["He said &quot;Hi&quot;"]`
+  - Avoid: `A["He said \"Hi\""]` (Mermaid does not support `\"`)
+
 - FL-DIR-MISSING
   - When: Diagram header lacks a direction after `flowchart`/`graph`.
   - Message: "Missing direction after diagram header. Use TD, TB, BT, RL, or LR."

--- a/scripts/dev-dump-parse.js
+++ b/scripts/dev-dump-parse.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Lazy import compiled JS from out/
+const flowLexer = await import('../out/diagrams/flowchart/lexer.js');
+const flowParser = await import('../out/diagrams/flowchart/parser.js');
+
+function dump(obj) {
+  return JSON.stringify(obj, (k, v) => {
+    if (k === 'image' && typeof v === 'string' && v.length > 120) {
+      return v.slice(0, 120) + '…';
+    }
+    return v;
+  }, 2);
+}
+
+function parseFlowchart(text) {
+  const lex = flowLexer.MermaidLexer.tokenize(text);
+  const res = flowParser.parse(lex.tokens);
+  return { lex, res };
+}
+
+function main() {
+  const rel = process.argv[2];
+  if (!rel) {
+    console.error('Usage: node scripts/dev-dump-parse.js <file.mmd>');
+    process.exit(1);
+  }
+  const file = path.resolve(__dirname, '..', rel);
+  const text = fs.readFileSync(file, 'utf8');
+  const { lex, res } = parseFlowchart(text);
+  console.log('LEX ERRORS:', lex.errors);
+  const parsed = res.errors.map(e => ({
+    name: e.name,
+    message: e.message,
+    token: {
+      image: e.token?.image,
+      startLine: e.token?.startLine,
+      startColumn: e.token?.startColumn,
+      tokenType: e.token?.tokenType?.name,
+    },
+    context: e.context ? {
+      ruleStack: Array.isArray(e.context.ruleStack) ? [...e.context.ruleStack] : e.context.ruleStack,
+      ruleOccurrenceStack: Array.isArray(e.context.ruleOccurrenceStack) ? [...e.context.ruleOccurrenceStack] : e.context.ruleOccurrenceStack,
+      expectedTokens: e.context.expectedTokens ? e.context.expectedTokens.map(t => t.name) : undefined,
+    } : undefined
+  }));
+  console.log('\nPARSE ERRORS JSON:');
+  console.log(dump(parsed));
+}
+
+main();

--- a/scripts/generate-invalid-preview.js
+++ b/scripts/generate-invalid-preview.js
@@ -166,7 +166,8 @@ This file contains invalid ${diagramType} test fixtures with:
       'special-chars': '❌ **Error**: Escaped quotes with backslash not supported in node labels.',
       'unclosed-bracket': '❌ **Error**: All brackets must be properly closed.',
       'unmatched-end': '❌ **Error**: `end` keyword without matching `subgraph`.',
-      'wrong-direction': '❌ **Error**: Invalid direction. Must be one of: TD, TB, BT, RL, LR.'
+      'wrong-direction': '❌ **Error**: Invalid direction. Must be one of: TD, TB, BT, RL, LR.',
+      'unquoted-label-with-quotes': '❌ **Error**: Label contains double quotes without quoting the whole label. Wrap the entire label in quotes or use &quot; for inner quotes.'
     };
     
     const key = file.replace('.mmd', '');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,8 +29,9 @@ function main() {
         process.exit(args.length === 0 ? 1 : 0);
     }
 
-    // simple arg parsing: --format json|human (consume flag + value)
+    // simple arg parsing: --format json|human (consume flag + value) and --strict
     let format: 'human' | 'json' = 'human';
+    let strict = false;
     const positionals: string[] = [];
     for (let i = 0; i < args.length; i++) {
         const a = args[i];
@@ -42,11 +43,12 @@ function main() {
                 continue;
             }
         }
+        if (a === '--strict' || a === '-s') { strict = true; continue; }
         if (!a.startsWith('-')) positionals.push(a);
     }
     const target = positionals[0] || args[0];
     const { content, filename } = readInput(target);
-    const { errors } = validate(content);
+    const { errors } = validate(content, { strict });
 
     const errorCount = errors.filter(e => e.severity === 'error').length;
     const warningCount = errors.filter(e => e.severity === 'warning').length;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 import * as fs from 'node:fs';
 import { validate } from './core/router.js';
 import type { ValidationError } from './core/types.js';
+import { humanReport, toJsonResult } from './core/format.js';
 
 // Main CLI execution
 function printUsage() {
@@ -28,47 +29,37 @@ function main() {
         process.exit(args.length === 0 ? 1 : 0);
     }
 
-    const { content, filename } = readInput(args[0]);
+    // simple arg parsing: --format json|human (consume flag + value)
+    let format: 'human' | 'json' = 'human';
+    const positionals: string[] = [];
+    for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a === '--format' || a === '-f') {
+            const v = (args[i + 1] || '').toLowerCase();
+            if (v === 'json' || v === 'human') {
+                format = v as any;
+                i++; // skip value
+                continue;
+            }
+        }
+        if (!a.startsWith('-')) positionals.push(a);
+    }
+    const target = positionals[0] || args[0];
+    const { content, filename } = readInput(target);
     const { errors } = validate(content);
 
     const errorCount = errors.filter(e => e.severity === 'error').length;
     const warningCount = errors.filter(e => e.severity === 'warning').length;
 
-    if (errorCount === 0 && warningCount === 0) {
-        console.log('Valid');
-        process.exit(0);
-    } else if (errorCount === 0) {
-        // Only warnings - still valid
-        if (warningCount > 0) {
-            console.error(`Found ${warningCount} warning(s) in ${filename}:\n`);
-            errors.filter(e => e.severity === 'warning').forEach(warning => {
-                const code = warning.code ? ` [${warning.code}]` : '';
-                console.error(`\x1b[33mwarning\x1b[0m: ${filename}:${warning.line}:${warning.column}${code} - ${warning.message}`);
-                if (warning.hint) console.error(`        hint: ${warning.hint}`);
-            });
-        }
-        console.log('Valid'); // File is still valid despite warnings
-        process.exit(0);
+    if (format === 'json') {
+        const json = toJsonResult(filename, errors);
+        console.log(JSON.stringify(json, null, 2));
+        process.exit(json.valid ? 0 : 1);
     } else {
-        // Has errors
-        console.error(`Found ${errorCount} error(s) in ${filename}:\n`);
-
-        errors.filter(e => e.severity === 'error').forEach(error => {
-            const code = error.code ? ` [${error.code}]` : '';
-            console.error(`\x1b[31merror\x1b[0m: ${filename}:${error.line}:${error.column}${code} - ${error.message}`);
-            if (error.hint) console.error(`        hint: ${error.hint}`);
-        });
-
-        if (warningCount > 0) {
-            console.error(`\nFound ${warningCount} warning(s) in ${filename}:\n`);
-            errors.filter(e => e.severity === 'warning').forEach(warning => {
-                const code = warning.code ? ` [${warning.code}]` : '';
-                console.error(`\x1b[33mwarning\x1b[0m: ${filename}:${warning.line}:${warning.column}${code} - ${warning.message}`);
-                if (warning.hint) console.error(`        hint: ${warning.hint}`);
-            });
-        }
-
-        process.exit(1);
+        const report = humanReport(filename, content, errors);
+        const outTo = errorCount > 0 ? 'stderr' : 'stdout';
+        if (outTo === 'stderr') console.error(report); else console.log(report);
+        process.exit(errorCount > 0 ? 1 : 0);
     }
 }
 

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -1,0 +1,231 @@
+import type { ILexingError, IRecognitionException, IToken } from 'chevrotain';
+import type { ValidationError } from './types.js';
+
+export function coercePos(line?: number | null, column?: number | null, fallbackLine = 1, fallbackColumn = 1) {
+  const ln = Number.isFinite(line as number) && (line as number)! > 0 ? (line as number) : fallbackLine;
+  const col = Number.isFinite(column as number) && (column as number)! > 0 ? (column as number) : fallbackColumn;
+  return { line: ln, column: col };
+}
+
+export function endOfTextPos(text: string) {
+  const lines = text.split(/\r?\n/);
+  const line = lines.length;
+  const last = lines[lines.length - 1] ?? '';
+  const column = Math.max(1, last.length + 1);
+  return { line, column };
+}
+
+export function codeFrame(
+  text: string,
+  line: number,
+  column: number,
+  length = 1,
+  contextLines = 1
+): string {
+  const lines = text.split(/\r?\n/);
+  const idx = Math.max(0, Math.min(lines.length - 1, line - 1));
+  const start = Math.max(0, idx - contextLines);
+  const end = Math.min(lines.length - 1, idx + contextLines);
+  const numWidth = String(end + 1).length;
+
+  const parts: string[] = [];
+  for (let i = start; i <= end; i++) {
+    const lno = String(i + 1).padStart(numWidth, ' ');
+    parts.push(`${lno} | ${lines[i] ?? ''}`);
+    if (i === idx) {
+      const caretPad = ' '.repeat(Math.max(0, column - 1));
+      const marker = '^'.repeat(Math.max(1, Math.min(length, (lines[i] ?? '').length - column + 1)));
+      parts.push(`${' '.repeat(numWidth)} | ${caretPad}${marker}`);
+    }
+  }
+  return parts.join('\n');
+}
+
+export function fromLexerError(e: ILexingError): ValidationError {
+  const { line, column } = coercePos(e.line, e.column);
+  return {
+    line,
+    column,
+    severity: 'error',
+    message: e.message,
+  };
+}
+
+// Helpers
+function tokenImage(t?: IToken | null) {
+  const img = t?.image ?? '';
+  return img === '\n' ? '\\n' : img;
+}
+
+function isInRule(err: IRecognitionException, name: string) {
+  const stack: string[] | undefined = (err as any)?.context?.ruleStack;
+  return Array.isArray(stack) && stack.includes(name);
+}
+
+function expecting(err: IRecognitionException, tokenName: string) {
+  // Chevrotain does not always expose expected tokens structurally; fall back to message text.
+  return (err.message || '').includes(`--> ${tokenName} <--`);
+}
+
+function atHeader(err: IRecognitionException) {
+  const stack: string[] | undefined = (err as any)?.context?.ruleStack;
+  return Array.isArray(stack) && stack.length === 1 && stack[0] === 'diagram';
+}
+
+export function mapFlowchartParserError(err: IRecognitionException, text: string): ValidationError {
+  const tok = err.token;
+  const posFallback = endOfTextPos(text);
+  const { line, column } = coercePos(tok?.startLine ?? null, tok?.startColumn ?? null, posFallback.line, posFallback.column);
+  const found = tokenImage(tok);
+  const tokType = tok?.tokenType?.name;
+
+  // 1) Direction after header
+  if (atHeader(err) && expecting(err, 'Direction')) {
+    if (tokType === 'EOF') {
+      return {
+        line, column, severity: 'error', code: 'FL-DIR-MISSING',
+        message: 'Missing direction after diagram header. Use TD, TB, BT, RL, or LR.',
+        hint: "Example: 'flowchart TD' for top-down layout."
+      };
+    }
+    return {
+      line, column, severity: 'error', code: 'FL-DIR-INVALID',
+      message: `Invalid direction '${found}'. Use one of: TD, TB, BT, RL, LR.`,
+      hint: "Try 'TD' (top-down) or 'LR' (left-to-right)."
+    };
+  }
+
+  // 2) Missing arrow between nodes on the same line
+  if (isInRule(err, 'nodeStatement') && err.name === 'NoViableAltException') {
+    // Common pattern: expecting Newline/EOF but found Identifier
+    if ((err.message || '').includes('[Newline') && (err.message || '').includes('[EOF')) {
+      return {
+        line, column, severity: 'error', code: 'FL-LINK-MISSING',
+        message: `Two nodes on one line must be connected with an arrow before '${found}'.`,
+        hint: 'Insert --> between nodes, e.g., A --> B.'
+      };
+    }
+  }
+
+  // 3) Mixed brackets: opened '(' closed with ']'
+  if (isInRule(err, 'nodeShape') && err.name === 'MismatchedTokenException' && tokType === 'SquareClose' && expecting(err, 'RoundClose')) {
+    return {
+      line, column, severity: 'error', code: 'FL-NODE-MIXED-BRACKETS',
+      message: "Mismatched brackets: opened '(' but closed with ']'.",
+      hint: "Close with ')' or change the opening bracket to '['."
+    };
+  }
+
+  // 4) Unclosed/mismatched brackets inside a node
+  if (isInRule(err, 'nodeShape') && err.name === 'MismatchedTokenException') {
+    if (expecting(err, 'SquareClose')) {
+      return { line, column, severity: 'error', code: 'FL-NODE-UNCLOSED-BRACKET', message: "Unclosed '['. Add a matching ']' before the arrow or newline.", hint: "Example: A[Label] --> B" };
+    }
+    if (expecting(err, 'RoundClose')) {
+      return { line, column, severity: 'error', code: 'FL-NODE-UNCLOSED-BRACKET', message: "Unclosed '('. Add a matching ')'.", hint: "Example: B(Label)" };
+    }
+    if (expecting(err, 'DiamondClose')) {
+      return { line, column, severity: 'error', code: 'FL-NODE-UNCLOSED-BRACKET', message: "Unclosed '{'. Add a matching '}'.", hint: "Example: C{Decision}" };
+    }
+    if (expecting(err, 'DoubleRoundClose')) {
+      return { line, column, severity: 'error', code: 'FL-NODE-UNCLOSED-BRACKET', message: "Unclosed '(( '. Add a matching '))'.", hint: "Example: A((Circle))" };
+    }
+    if (expecting(err, 'DoubleSquareClose')) {
+      return { line, column, severity: 'error', code: 'FL-NODE-UNCLOSED-BRACKET', message: "Unclosed '[[ '. Add a matching ']]'.", hint: "Example: [[Subroutine]]" };
+    }
+  }
+
+  
+
+  // 5) Invalid/Incomplete class statement
+  if (isInRule(err, 'classStatement')) {
+    return {
+      line, column, severity: 'error', code: 'FL-CLASS-MALFORMED',
+      message: 'Invalid class statement. Provide node id(s) then a class name.',
+      hint: 'Example: class A,B important'
+    };
+  }
+
+  // 6) Subgraph requires header (id or [Title])
+  if (isInRule(err, 'subgraph') && err.name === 'NoViableAltException') {
+    return {
+      line, column, severity: 'error', code: 'FL-SUBGRAPH-MISSING-HEADER',
+      message: 'Subgraph header is missing. Add an ID or a [Title] after the keyword.',
+      hint: 'Example: subgraph API [API Layer]'
+    };
+  }
+
+  // 7) Unmatched 'end' with no open subgraph
+  if (err.name === 'NotAllInputParsedException' && tokType === 'EndKeyword') {
+    return {
+      line, column, severity: 'error', code: 'FL-END-WITHOUT-SUBGRAPH',
+      message: "'end' without a matching 'subgraph'.",
+      hint: 'Remove this end or add a subgraph above.'
+    };
+  }
+
+  // Default: keep original message
+  return {
+    line,
+    column,
+    severity: 'error',
+    message: err.message || 'Parser error',
+  };
+}
+
+export function mapPieParserError(err: IRecognitionException, text: string): ValidationError {
+  const tok = err.token;
+  const posFallback = endOfTextPos(text);
+  const { line, column } = coercePos(tok?.startLine ?? null, tok?.startColumn ?? null, posFallback.line, posFallback.column);
+  const found = tokenImage(tok);
+
+  // Colon at top-level usually means missing quoted label before it
+  if (err.name === 'NotAllInputParsedException' && tok?.tokenType?.name === 'Colon') {
+    return {
+      line, column, severity: 'error', code: 'PI-LABEL-REQUIRES-QUOTES',
+      message: 'Slice labels must be quoted (single or double quotes).',
+      hint: 'Example: "Dogs" : 10'
+    };
+  }
+
+  // Unclosed quote: token looks like it starts with a quote but never closed
+  if (err.name === 'NotAllInputParsedException' && typeof tok?.image === 'string') {
+    const s = tok.image as string;
+    if ((s.startsWith('"') && !s.slice(1).includes('"')) || (s.startsWith("'") && !s.slice(1).includes("'"))) {
+      return {
+        line, column, severity: 'error', code: 'PI-QUOTE-UNCLOSED',
+        message: 'Unclosed quote in slice label.',
+        hint: 'Close the quote: "Dogs" : 10'
+      };
+    }
+  }
+
+  // Missing colon between label and number
+  if (expecting(err, 'Colon')) {
+    return {
+      line, column, severity: 'error', code: 'PI-MISSING-COLON',
+      message: 'Missing colon between slice label and value.',
+      hint: 'Use: "Label" : 10'
+    };
+  }
+
+  // Missing number after colon
+  if (expecting(err, 'NumberLiteral')) {
+    return {
+      line, column, severity: 'error', code: 'PI-MISSING-NUMBER',
+      message: 'Missing numeric value after colon.',
+      hint: 'Use a number like 10 or 42.5'
+    };
+  }
+
+  // Unquoted label
+  if (expecting(err, 'QuotedString')) {
+    return {
+      line, column, severity: 'error', code: 'PI-LABEL-REQUIRES-QUOTES',
+      message: 'Slice labels must be quoted (single or double quotes).',
+      hint: 'Example: "Dogs" : 10'
+    };
+  }
+
+  return { line, column, severity: 'error', message: err.message || 'Parser error' };
+}

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -140,6 +140,16 @@ export function mapFlowchartParserError(err: IRecognitionException, text: string
     }
   }
 
+  // 4b) Quotes appear inside an unquoted label content
+  if (isInRule(err, 'nodeContent') && err.name === 'MismatchedTokenException' && tokType === 'QuotedString') {
+    return {
+      line, column, severity: 'error', code: 'FL-LABEL-QUOTE-IN-UNQUOTED',
+      message: 'Double quotes inside an unquoted label are not allowed. Wrap the entire label in quotes or use &quot;.',
+      hint: 'Example: A["Calls logger.debug(&quot;message&quot;, data)"]',
+      length: len
+    };
+  }
+
   
 
   // 5) Invalid/Incomplete class statement

--- a/src/core/errorBuilder.ts
+++ b/src/core/errorBuilder.ts
@@ -1,0 +1,24 @@
+import type { IToken } from 'chevrotain';
+import type { ValidationError } from './types.js';
+import { coercePos } from './diagnostics.js';
+
+type Common = {
+  code?: string;
+  hint?: string;
+  length?: number;
+};
+
+export function errorAt(line: number | null | undefined, column: number | null | undefined, message: string, extra: Common = {}): ValidationError {
+  const pos = coercePos(line ?? null, column ?? null, 1, 1);
+  return { line: pos.line, column: pos.column, message, severity: 'error', ...extra };
+}
+
+export function errorAtToken(tok: IToken | undefined | null, message: string, extra: Common = {}): ValidationError {
+  return errorAt(tok?.startLine, tok?.startColumn, message, extra);
+}
+
+export function warningAt(line: number | null | undefined, column: number | null | undefined, message: string, extra: Omit<Common, 'code'> & { code?: string } = {}): ValidationError {
+  const pos = coercePos(line ?? null, column ?? null, 1, 1);
+  return { line: pos.line, column: pos.column, message, severity: 'warning', ...extra } as ValidationError;
+}
+

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -1,0 +1,56 @@
+import type { ValidationError } from './types.js';
+import { codeFrame } from './diagnostics.js';
+
+export type OutputFormat = 'human' | 'json';
+
+export function groupErrors(errors: ValidationError[]) {
+  const errs = errors.filter(e => e.severity === 'error');
+  const warns = errors.filter(e => e.severity === 'warning');
+  return { errs, warns };
+}
+
+export function humanReport(filename: string, content: string, errors: ValidationError[]): string {
+  const { errs, warns } = groupErrors(errors);
+  const lines: string[] = [];
+  if (errs.length > 0) {
+    lines.push(`Found ${errs.length} error(s) in ${filename}:\n`);
+    for (const error of errs) {
+      const code = error.code ? ` [${error.code}]` : '';
+      lines.push(`\x1b[31merror\x1b[0m: ${filename}:${error.line}:${error.column}${code} - ${error.message}`);
+      if (error.hint) lines.push(`        hint: ${error.hint}`);
+      try {
+        const frame = codeFrame(content, error.line, error.column, Math.max(1, error.length ?? 1));
+        lines.push(frame.split('\n').map(l => '        ' + l).join('\n'));
+      } catch {}
+    }
+  }
+  if (warns.length > 0) {
+    lines.push(`\nFound ${warns.length} warning(s) in ${filename}:\n`);
+    for (const w of warns) {
+      const code = w.code ? ` [${w.code}]` : '';
+      lines.push(`\x1b[33mwarning\x1b[0m: ${filename}:${w.line}:${w.column}${code} - ${w.message}`);
+      if (w.hint) lines.push(`        hint: ${w.hint}`);
+      try {
+        const frame = codeFrame(content, w.line, w.column, Math.max(1, w.length ?? 1));
+        lines.push(frame.split('\n').map(l => '        ' + l).join('\n'));
+      } catch {}
+    }
+  }
+  if (errs.length === 0 && warns.length === 0) {
+    lines.push('Valid');
+  }
+  return lines.join('\n');
+}
+
+export function toJsonResult(filename: string, errors: ValidationError[]) {
+  const { errs, warns } = groupErrors(errors);
+  return {
+    file: filename,
+    valid: errs.length === 0,
+    errorCount: errs.length,
+    warningCount: warns.length,
+    errors: errs,
+    warnings: warns,
+  };
+}
+

--- a/src/core/pipeline.ts
+++ b/src/core/pipeline.ts
@@ -1,0 +1,52 @@
+import type { ILexingError, IRecognitionException, IToken } from 'chevrotain';
+import type { ValidationError } from './types.js';
+import { fromLexerError } from './diagnostics.js';
+
+export interface LintAdapters {
+  tokenize: (text: string) => { tokens: IToken[]; errors: ILexingError[] };
+  parse: (tokens: IToken[]) => { cst: any; errors: IRecognitionException[] };
+  analyze: (cst: any, tokens: IToken[]) => ValidationError[];
+  mapParserError: (err: IRecognitionException, text: string) => ValidationError;
+  postLex?: (text: string, tokens: IToken[]) => ValidationError[];
+  postParse?: (text: string, tokens: IToken[], cst: any, prevErrors: ValidationError[]) => ValidationError[];
+}
+
+export function lintWithChevrotain(text: string, adapters: LintAdapters): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  // Lexing
+  const lex = adapters.tokenize(text);
+  if (lex.errors.length > 0) {
+    errors.push(...lex.errors.map(fromLexerError));
+  }
+
+  // Diagram-specific token checks
+  if (adapters.postLex) {
+    try { errors.push(...(adapters.postLex(text, lex.tokens) || [])); } catch {}
+  }
+
+  // Parsing (only if no fatal lexer errors)
+  let cst: any | null = null;
+  if (errors.filter(e => e.severity === 'error').length === 0) {
+    const parseRes = adapters.parse(lex.tokens);
+    cst = parseRes.cst;
+    if (parseRes.errors.length > 0) {
+      errors.push(...parseRes.errors.map((e) => adapters.mapParserError(e, text)));
+    }
+  }
+
+  // Semantics
+  if (cst) {
+    try { errors.push(...(adapters.analyze(cst, lex.tokens) || [])); } catch (e) {
+      errors.push({ line: 1, column: 1, severity: 'error', message: `Internal semantic analysis error: ${(e as Error).message}` });
+    }
+  }
+
+  // Post-parse hooks
+  if (cst && adapters.postParse) {
+    try { errors.push(...(adapters.postParse(text, lex.tokens, cst, errors) || [])); } catch {}
+  }
+
+  return errors;
+}
+

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -38,9 +38,10 @@ export function validate(text: string): { type: DiagramType; errors: ValidationE
             column: 1,
             message: 'Diagram must start with "graph", "flowchart", or "pie"',
             severity: 'error',
+            code: 'GEN-HEADER-INVALID',
+            hint: 'Start your diagram with e.g. "flowchart TD" or "pie".'
           },
         ],
       };
   }
 }
-

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -1,4 +1,4 @@
-import { ValidationError, DiagramType } from './types.js';
+import { ValidationError, DiagramType, ValidateOptions } from './types.js';
 import { validateFlowchart } from '../diagrams/flowchart/validate.js';
 import { validatePie } from '../diagrams/pie/validate.js';
 
@@ -22,13 +22,13 @@ export function detectDiagramType(text: string): DiagramType {
   return 'unknown';
 }
 
-export function validate(text: string): { type: DiagramType; errors: ValidationError[] } {
+export function validate(text: string, options: ValidateOptions = {}): { type: DiagramType; errors: ValidationError[] } {
   const type = detectDiagramType(text);
   switch (type) {
     case 'flowchart':
-      return { type, errors: validateFlowchart(text) };
+      return { type, errors: validateFlowchart(text, options) };
     case 'pie':
-      return { type, errors: validatePie(text) };
+      return { type, errors: validatePie(text, options) };
     default:
       return {
         type,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -9,3 +9,7 @@ export interface ValidationError {
 }
 
 export type DiagramType = 'flowchart' | 'pie' | 'unknown';
+
+export interface ValidateOptions {
+  strict?: boolean;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,6 +5,7 @@ export interface ValidationError {
   severity: 'error' | 'warning';
   code?: string;
   hint?: string;
+  length?: number;
 }
 
 export type DiagramType = 'flowchart' | 'pie' | 'unknown';

--- a/src/diagrams/_template/README.md
+++ b/src/diagrams/_template/README.md
@@ -1,0 +1,16 @@
+This is a scaffold for adding a new Mermaid diagram validator.
+
+Wire it as follows:
+
+1) Implement a Chevrotain lexer and parser in `lexer.ts` and `parser.ts`.
+2) Provide a minimal semantics visitor (optional) in `semantics.ts`.
+3) Use the shared pipeline in `validate.ts`:
+
+   - `tokenize(text)` → `{ tokens, errors }`
+   - `parse(tokens)` → `{ cst, errors }`
+   - `analyze(cst, tokens)` → `ValidationError[]`
+   - `mapParserError(err, text)` → `ValidationError` (diagram‑specific mapping)
+   - Optional hooks: `postLex`, `postParse`
+
+4) Register header detection + router entry in `src/core/router.ts`.
+

--- a/src/diagrams/_template/validate.ts
+++ b/src/diagrams/_template/validate.ts
@@ -1,0 +1,22 @@
+import type { ValidationError } from '../../core/types.js';
+import { lintWithChevrotain } from '../../core/pipeline.js';
+
+// Placeholder imports – replace with your diagram's modules
+// import { tokenize } from './lexer.js';
+// import { parse } from './parser.js';
+// import { analyze } from './semantics.js';
+// import { mapParserError } from './map-errors.js';
+
+export function validateTemplateDiagram(_text: string): ValidationError[] {
+  // Example wiring – uncomment and adapt when implementing a new diagram:
+  // return lintWithChevrotain(text, {
+  //   tokenize,
+  //   parse,
+  //   analyze,
+  //   mapParserError,
+  //   postLex: (text, tokens) => [],
+  //   postParse: (text, tokens, cst, prev) => [],
+  // });
+  return [];
+}
+

--- a/src/diagrams/flowchart/lexer.ts
+++ b/src/diagrams/flowchart/lexer.ts
@@ -328,10 +328,6 @@ export const MermaidLexer = new Lexer(allTokens);
 // Helper function to tokenize input
 export function tokenize(text: string) {
     const lexResult = MermaidLexer.tokenize(text);
-    
-    if (lexResult.errors.length > 0) {
-        console.error('Lexer errors:', lexResult.errors);
-    }
-    
+    // Do not log lexer errors directly; callers produce user-facing diagnostics.
     return lexResult;
 }

--- a/src/diagrams/flowchart/parser.ts
+++ b/src/diagrams/flowchart/parser.ts
@@ -58,6 +58,8 @@ export class MermaidParser extends CstParser {
             });
         });
         
+        // Optional semicolon terminator
+        this.OPTION2(() => this.CONSUME(tokens.Semicolon));
         // Statement must end at newline or EOF (prevents multiple nodes on one line without arrows)
         this.OR2([
             { ALT: () => this.CONSUME(tokens.Newline) },
@@ -193,7 +195,12 @@ export class MermaidParser extends CstParser {
                             { ALT: () => this.CONSUME(tokens.RoundOpen) },
                             { ALT: () => this.CONSUME(tokens.RoundClose) },
                             { ALT: () => this.CONSUME(tokens.Comma) },
-                            { ALT: () => this.CONSUME(tokens.Colon) }
+                            { ALT: () => this.CONSUME(tokens.Colon) },
+                            // Allow hyphens/lines inside labels without forcing them to be links
+                            { ALT: () => this.CONSUME(tokens.TwoDashes) },
+                            { ALT: () => this.CONSUME(tokens.Line) },
+                            { ALT: () => this.CONSUME(tokens.ThickLine) },
+                            { ALT: () => this.CONSUME(tokens.DottedLine) }
                         ]);
                     });
                 }

--- a/src/diagrams/flowchart/semantics.ts
+++ b/src/diagrams/flowchart/semantics.ts
@@ -131,9 +131,9 @@ class FlowSemanticsVisitor extends BaseVisitor {
             line: t.startLine ?? 1,
             column: t.startColumn ?? 1,
             severity: 'error',
-            message: 'Escaped quotes (\\") in node labels are not supported by Mermaid. Use &quot; or switch to single quotes.',
+            message: 'Escaped quotes (\\") in node labels are not supported by Mermaid. Use &quot; instead.',
             code: 'FL-LABEL-ESCAPED-QUOTE',
-            hint: 'Prefer "He said &quot;Hi&quot;" or use single quotes around the label.'
+            hint: 'Prefer "He said &quot;Hi&quot;".'
           });
         }
       }
@@ -152,9 +152,9 @@ class FlowSemanticsVisitor extends BaseVisitor {
             line: q.startLine ?? 1,
             column: q.startColumn ?? 1,
             severity: 'error',
-            message: 'Double quotes inside a single-quoted label are not supported by Mermaid. Use double-quoted label or replace " with &quot;.',
+            message: 'Double quotes inside a single-quoted label are not supported by Mermaid. Replace inner " with &quot; or use a double-quoted label with &quot;.',
             code: 'FL-LABEL-DOUBLE-IN-SINGLE',
-            hint: 'Change to "She said \"Hello\"" or replace inner " with &quot;.'
+            hint: 'Change to "She said &quot;Hello&quot;" or replace inner " with &quot;.'
           });
         }
       }

--- a/src/diagrams/flowchart/validate.ts
+++ b/src/diagrams/flowchart/validate.ts
@@ -22,7 +22,8 @@ export function validateFlowchart(text: string): ValidationError[] {
             message: 'Invalid arrow syntax: -> (use --> instead)',
             severity: 'error',
             code: 'FL-ARROW-INVALID',
-            hint: 'Replace -> with -->, or use -- text --> for inline labels.'
+            hint: 'Replace -> with -->, or use -- text --> for inline labels.',
+            length: (token.image?.length ?? 2)
           });
         }
       }
@@ -33,11 +34,14 @@ export function validateFlowchart(text: string): ValidationError[] {
       if (prevErrors.some(e => e.code === 'FL-LABEL-ESCAPED-QUOTE')) return [];
       for (const tok of tokens as IToken[]) {
         if (typeof tok.image === 'string' && tok.image.includes('\\"')) {
-          const { line, column } = coercePos(tok.startLine ?? null, tok.startColumn ?? null, 1, 1);
+          const idx = tok.image.indexOf('\\"');
+          const col = (tok.startColumn ?? 1) + Math.max(0, idx);
+          const { line, column } = coercePos(tok.startLine ?? null, col, 1, 1);
           return [{
             line, column, severity: 'error', code: 'FL-LABEL-ESCAPED-QUOTE',
             message: 'Escaped quotes (\\") in node labels are not supported by Mermaid. Use &quot; instead.',
-            hint: 'Prefer "He said &quot;Hi&quot;".'
+            hint: 'Prefer "He said &quot;Hi&quot;".',
+            length: 2
           }];
         }
       }

--- a/src/diagrams/flowchart/validate.ts
+++ b/src/diagrams/flowchart/validate.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from '../../core/types.js';
+import type { ValidationError, ValidateOptions } from '../../core/types.js';
 import { tokenize, InvalidArrow } from './lexer.js';
 import { parse } from './parser.js';
 import { analyzeFlowchart } from './semantics.js';
@@ -6,11 +6,11 @@ import type { IToken } from 'chevrotain';
 import { lintWithChevrotain } from '../../core/pipeline.js';
 import { coercePos, mapFlowchartParserError } from '../../core/diagnostics.js';
 
-export function validateFlowchart(text: string): ValidationError[] {
+export function validateFlowchart(text: string, options: ValidateOptions = {}): ValidationError[] {
   return lintWithChevrotain(text, {
     tokenize,
     parse,
-    analyze: (cst, tokens) => analyzeFlowchart(cst as any, tokens as IToken[]),
+    analyze: (cst, tokens) => analyzeFlowchart(cst as any, tokens as IToken[], { strict: !!options.strict }),
     mapParserError: (e, t) => mapFlowchartParserError(e, t),
     postLex: (_text, tokens) => {
       const errs: ValidationError[] = [];

--- a/src/diagrams/flowchart/validate.ts
+++ b/src/diagrams/flowchart/validate.ts
@@ -36,8 +36,8 @@ export function validateFlowchart(text: string): ValidationError[] {
           const { line, column } = coercePos(tok.startLine ?? null, tok.startColumn ?? null, 1, 1);
           return [{
             line, column, severity: 'error', code: 'FL-LABEL-ESCAPED-QUOTE',
-            message: 'Escaped quotes (\\") in node labels are not supported by Mermaid. Use &quot; or switch to single quotes.',
-            hint: 'Prefer "He said &quot;Hi&quot;" or use single quotes around the label.'
+            message: 'Escaped quotes (\\") in node labels are not supported by Mermaid. Use &quot; instead.',
+            hint: 'Prefer "He said &quot;Hi&quot;".'
           }];
         }
       }

--- a/src/diagrams/pie/validate.ts
+++ b/src/diagrams/pie/validate.ts
@@ -1,11 +1,11 @@
-import type { ValidationError } from '../../core/types.js';
+import type { ValidationError, ValidateOptions } from '../../core/types.js';
 import { tokenize } from './lexer.js';
 import { parse } from './parser.js';
 import { analyzePie } from './semantics.js';
 import { lintWithChevrotain } from '../../core/pipeline.js';
 import { mapPieParserError } from '../../core/diagnostics.js';
 
-export function validatePie(text: string): ValidationError[] {
+export function validatePie(text: string, _options: ValidateOptions = {}): ValidationError[] {
   return lintWithChevrotain(text, {
     tokenize,
     parse,

--- a/src/diagrams/pie/validate.ts
+++ b/src/diagrams/pie/validate.ts
@@ -2,51 +2,14 @@ import type { ValidationError } from '../../core/types.js';
 import { tokenize } from './lexer.js';
 import { parse } from './parser.js';
 import { analyzePie } from './semantics.js';
-import type { ILexingError, IRecognitionException } from 'chevrotain';
+import { lintWithChevrotain } from '../../core/pipeline.js';
+import { mapPieParserError } from '../../core/diagnostics.js';
 
 export function validatePie(text: string): ValidationError[] {
-  const errors: ValidationError[] = [];
-  const lexResult = tokenize(text);
-
-  // Lexer errors
-  if (lexResult.errors.length > 0) {
-    lexResult.errors.forEach((error: ILexingError) => {
-      errors.push({
-        line: error.line ?? 1,
-        column: error.column ?? 1,
-        message: error.message,
-        severity: 'error',
-      });
-    });
-  }
-
-  if (errors.filter((e) => e.severity === 'error').length === 0) {
-    const parseResult = parse(lexResult.tokens);
-    if (parseResult.errors.length > 0) {
-      parseResult.errors.forEach((error: IRecognitionException) => {
-        const token = error.token;
-        errors.push({
-          line: token?.startLine ?? 1,
-          column: token?.startColumn ?? 1,
-          message: error.message || 'Parser error',
-          severity: 'error',
-        });
-      });
-    }
-    // Minimal semantic pass (currently no additional rules to keep mermaid parity)
-    try {
-      const semanticErrors = analyzePie(parseResult.cst as any, lexResult.tokens);
-      errors.push(...semanticErrors);
-    } catch (e) {
-      errors.push({
-        line: 1,
-        column: 1,
-        severity: 'error',
-        message: `Internal semantic analysis error: ${(e as Error).message}`,
-      });
-    }
-  }
-
-  // Keep semantics minimal; rely on parser structure for now
-  return errors;
+  return lintWithChevrotain(text, {
+    tokenize,
+    parse,
+    analyze: (cst, tokens) => analyzePie(cst as any, tokens),
+    mapParserError: (e, t) => mapPieParserError(e, t),
+  });
 }

--- a/test-fixtures/flowchart/INVALID_DIAGRAMS.md
+++ b/test-fixtures/flowchart/INVALID_DIAGRAMS.md
@@ -23,7 +23,8 @@ This file contains invalid flowchart test fixtures with:
 12. [Special Chars](#12-special-chars)
 13. [Unclosed Bracket](#13-unclosed-bracket)
 14. [Unmatched End](#14-unmatched-end)
-15. [Wrong Direction](#15-wrong-direction)
+15. [Unquoted Label With Quotes](#15-unquoted-label-with-quotes)
+16. [Wrong Direction](#16-wrong-direction)
 
 ---
 
@@ -45,7 +46,8 @@ This file contains invalid flowchart test fixtures with:
 | 12 | [Special Chars](#12-special-chars) | INVALID | INVALID |
 | 13 | [Unclosed Bracket](#13-unclosed-bracket) | INVALID | INVALID |
 | 14 | [Unmatched End](#14-unmatched-end) | INVALID | INVALID |
-| 15 | [Wrong Direction](#15-wrong-direction) | INVALID | INVALID |
+| 15 | [Unquoted Label With Quotes](#15-unquoted-label-with-quotes) | INVALID | INVALID |
+| 16 | [Wrong Direction](#16-wrong-direction) | INVALID | INVALID |
 
 ---
 
@@ -114,25 +116,29 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 3 error(s) in test-fixtures/flowchart/invalid/empty-nodes.mmd:
+[31merror[0m[FL-NODE-EMPTY]: Empty node content is not allowed. Label cannot be just empty quotes.
+  [2m┌─ test-fixtures/flowchart/invalid/empty-nodes.mmd:2:7[0m
+  [2m│[0m
+  2 │     A[""] --> B[" "]
+  [2m│[0m       [31m^[0m
+  [2m│[0m
+  help: Use non-empty quoted text, e.g. "Start" or remove the quotes.
 
-[31merror[0m: test-fixtures/flowchart/invalid/empty-nodes.mmd:2:7 [FL-NODE-EMPTY] - Empty node content is not allowed. Label cannot be just empty quotes.
-        hint: Use non-empty quoted text, e.g. "Start" or remove the quotes.
-        1 | flowchart TD
-        2 |     A[""] --> B[" "]
-          |       ^
-        3 |     B --> C[]
-[31merror[0m: test-fixtures/flowchart/invalid/empty-nodes.mmd:2:17 [FL-NODE-EMPTY] - Empty node content is not allowed. Label cannot be just empty quotes.
-        hint: Use non-empty quoted text, e.g. "Start" or remove the quotes.
-        1 | flowchart TD
-        2 |     A[""] --> B[" "]
-          |                 ^
-        3 |     B --> C[]
-[31merror[0m: test-fixtures/flowchart/invalid/empty-nodes.mmd:3:12 [FL-NODE-EMPTY] - Empty node content is not allowed. Add a label inside the shape.
-        hint: Put some text inside [], (), {}, etc. For example: A[Start]
-        2 |     A[""] --> B[" "]
-        3 |     B --> C[]
-          |            ^
+[31merror[0m[FL-NODE-EMPTY]: Empty node content is not allowed. Label cannot be just empty quotes.
+  [2m┌─ test-fixtures/flowchart/invalid/empty-nodes.mmd:2:17[0m
+  [2m│[0m
+  2 │     A[""] --> B[" "]
+  [2m│[0m                 [31m^[0m
+  [2m│[0m
+  help: Use non-empty quoted text, e.g. "Start" or remove the quotes.
+
+[31merror[0m[FL-NODE-EMPTY]: Empty node content is not allowed. Add a label inside the shape.
+  [2m┌─ test-fixtures/flowchart/invalid/empty-nodes.mmd:3:12[0m
+  [2m│[0m
+  3 │     B --> C[]
+  [2m│[0m            [31m^[0m
+  [2m│[0m
+  help: Put some text inside [], (), {}, etc. For example: A[Start]
 ```
 
 <details>
@@ -190,14 +196,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/flowchart/invalid/escaped-quotes-in-decision.mmd:
-
-[31merror[0m: test-fixtures/flowchart/invalid/escaped-quotes-in-decision.mmd:6:30 [FL-NODE-UNCLOSED-BRACKET] - Unclosed '{'. Add a matching '}'.
-        hint: Example: C{Decision}
-        5 |         B -- No --> C[Continue with other auth methods]
-        6 |         B -- Yes --> D{"Is \"Driver\" AND \"AuthCheck.Path\" configured?"}
-          |                              ^
-        7 |     end
+[31merror[0m[FL-NODE-UNCLOSED-BRACKET]: Unclosed '{'. Add a matching '}'.
+  [2m┌─ test-fixtures/flowchart/invalid/escaped-quotes-in-decision.mmd:6:30[0m
+  [2m│[0m
+  6 │         B -- Yes --> D{"Is \"Driver\" AND \"AuthCheck.Path\" configured?"}
+  [2m│[0m                              [31m^[0m
+  [2m│[0m
+  help: Example: C{Decision}
 ```
 
 <details>
@@ -257,14 +262,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/flowchart/invalid/invalid-arrow.mmd:
-
-[31merror[0m: test-fixtures/flowchart/invalid/invalid-arrow.mmd:2:7 [FL-ARROW-INVALID] - Invalid arrow syntax: -> (use --> instead)
-        hint: Replace -> with -->, or use -- text --> for inline labels.
-        1 | flowchart TD
-        2 |     A -> B
-          |       ^
-        3 |     B --> C
+[31merror[0m[FL-ARROW-INVALID]: Invalid arrow syntax: -> (use --> instead)
+  [2m┌─ test-fixtures/flowchart/invalid/invalid-arrow.mmd:2:7[0m
+  [2m│[0m
+  2 │     A -> B
+  [2m│[0m       [31m^^[0m
+  [2m│[0m
+  help: Replace -> with -->, or use -- text --> for inline labels.
 ```
 
 <details>
@@ -318,13 +322,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/flowchart/invalid/invalid-class.mmd:
-
-[31merror[0m: test-fixtures/flowchart/invalid/invalid-class.mmd:3:12 [FL-CLASS-MALFORMED] - Invalid class statement. Provide node id(s) then a class name.
-        hint: Example: class A,B important
-        2 |     A --> B
-        3 |     class A
-          |            ^
+[31merror[0m[FL-CLASS-MALFORMED]: Invalid class statement. Provide node id(s) then a class name.
+  [2m┌─ test-fixtures/flowchart/invalid/invalid-class.mmd:3:12[0m
+  [2m│[0m
+  3 │     class A
+  [2m│[0m            [31m^[0m
+  [2m│[0m
+  help: Example: class A,B important
 ```
 
 <details>
@@ -378,14 +382,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/flowchart/invalid/invalid-node-syntax.mmd:
-
-[31merror[0m: test-fixtures/flowchart/invalid/invalid-node-syntax.mmd:2:9 [FL-NODE-UNCLOSED-BRACKET] - Unclosed '(( '. Add a matching '))'.
-        hint: Example: A((Circle))
-        1 | flowchart TD
-        2 |     A(( --> B
-          |         ^
-        3 |     B --> C
+[31merror[0m[FL-NODE-UNCLOSED-BRACKET]: Unclosed '(( '. Add a matching '))'.
+  [2m┌─ test-fixtures/flowchart/invalid/invalid-node-syntax.mmd:2:9[0m
+  [2m│[0m
+  2 │     A(( --> B
+  [2m│[0m         [31m^^[0m
+  [2m│[0m
+  help: Example: A((Circle))
 ```
 
 <details>
@@ -437,14 +440,13 @@ FlowDB.addSubGraph (node_modules/mermaid/dist/mermaid.js:45974:26)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/flowchart/invalid/invalid-subgraph.mmd:
-
-[31merror[0m: test-fixtures/flowchart/invalid/invalid-subgraph.mmd:2:13 [FL-SUBGRAPH-MISSING-HEADER] - Subgraph header is missing. Add an ID or a [Title] after the keyword.
-        hint: Example: subgraph API [API Layer]
-        1 | flowchart TD
-        2 |     subgraph
-          |             ^
-        3 |         A --> B
+[31merror[0m[FL-SUBGRAPH-MISSING-HEADER]: Subgraph header is missing. Add an ID or a [Title] after the keyword.
+  [2m┌─ test-fixtures/flowchart/invalid/invalid-subgraph.mmd:2:13[0m
+  [2m│[0m
+  2 │     subgraph
+  [2m│[0m             [31m^[0m
+  [2m│[0m
+  help: Example: subgraph API [API Layer]
 ```
 
 <details>
@@ -498,13 +500,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/flowchart/invalid/missing-arrow.mmd:
-
-[31merror[0m: test-fixtures/flowchart/invalid/missing-arrow.mmd:2:7 [FL-LINK-MISSING] - Two nodes on one line must be connected with an arrow before 'B'.
-        hint: Insert --> between nodes, e.g., A --> B.
-        1 | flowchart TD
-        2 |     A B
-          |       ^
+[31merror[0m[FL-LINK-MISSING]: Two nodes on one line must be connected with an arrow before 'B'.
+  [2m┌─ test-fixtures/flowchart/invalid/missing-arrow.mmd:2:7[0m
+  [2m│[0m
+  2 │     A B
+  [2m│[0m       [31m^[0m
+  [2m│[0m
+  help: Insert --> between nodes, e.g., A --> B.
 ```
 
 <details>
@@ -557,14 +559,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/flowchart/invalid/mixed-brackets.mmd:
-
-[31merror[0m: test-fixtures/flowchart/invalid/mixed-brackets.mmd:2:23 [FL-NODE-MIXED-BRACKETS] - Mismatched brackets: opened '(' but closed with ']'.
-        hint: Close with ')' or change the opening bracket to '['.
-        1 | flowchart LR
-        2 |     A[Text] --> B(Text]
-          |                       ^
-        3 |     B --> C
+[31merror[0m[FL-NODE-MIXED-BRACKETS]: Mismatched brackets: opened '(' but closed with ']'.
+  [2m┌─ test-fixtures/flowchart/invalid/mixed-brackets.mmd:2:23[0m
+  [2m│[0m
+  2 │     A[Text] --> B(Text]
+  [2m│[0m                       [31m^[0m
+  [2m│[0m
+  help: Close with ')' or change the opening bracket to '['.
 ```
 
 <details>
@@ -615,13 +616,13 @@ detectType (node_modules/mermaid/dist/mermaid.js:20437:15)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/flowchart/invalid/no-diagram-type.mmd:
-
-[31merror[0m: test-fixtures/flowchart/invalid/no-diagram-type.mmd:1:1 [GEN-HEADER-INVALID] - Diagram must start with "graph", "flowchart", or "pie"
-        hint: Start your diagram with e.g. "flowchart TD" or "pie".
-        1 | A --> B
-          | ^
-        2 | B --> C
+[31merror[0m[GEN-HEADER-INVALID]: Diagram must start with "graph", "flowchart", or "pie"
+  [2m┌─ test-fixtures/flowchart/invalid/no-diagram-type.mmd:1:1[0m
+  [2m│[0m
+  1 │ A --> B
+  [2m│[0m [31m^[0m
+  [2m│[0m
+  help: Start your diagram with e.g. "flowchart TD" or "pie".
 ```
 
 <details>
@@ -673,14 +674,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/flowchart/invalid/quotes-double-inside-single.mmd:
-
-[31merror[0m: test-fixtures/flowchart/invalid/quotes-double-inside-single.mmd:2:5 [FL-LABEL-DOUBLE-IN-SINGLE] - Double quotes inside a single-quoted label are not supported by Mermaid. Replace inner " with &quot; or use a double-quoted label with &quot;.
-        hint: Change to "She said &quot;Hello&quot;" or replace inner " with &quot;.
-        1 | flowchart LR
-        2 |   A['She said "Hello"'] --> B
-          |     ^
-        3 |
+[31merror[0m[FL-LABEL-DOUBLE-IN-SINGLE]: Double quotes inside a single-quoted label are not supported by Mermaid. Replace inner " with &quot; or use a double-quoted label with &quot;.
+  [2m┌─ test-fixtures/flowchart/invalid/quotes-double-inside-single.mmd:2:5[0m
+  [2m│[0m
+  2 │   A['She said "Hello"'] --> B
+  [2m│[0m     [31m^[0m
+  [2m│[0m
+  help: Change to "She said &quot;Hello&quot;" or replace inner " with &quot;.
 ```
 
 <details>
@@ -738,14 +738,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/flowchart/invalid/special-chars.mmd:
-
-[31merror[0m: test-fixtures/flowchart/invalid/special-chars.mmd:2:44 [FL-NODE-UNCLOSED-BRACKET] - Unclosed '['. Add a matching ']' before the arrow or newline.
-        hint: Example: A[Label] --> B
-        1 | flowchart LR
-        2 |     A["Node with quotes"] --> B["Another \"quoted\" node"]
-          |                                            ^
-        3 |     B --> C[Node with #35; special &amp; chars]
+[31merror[0m[FL-NODE-UNCLOSED-BRACKET]: Unclosed '['. Add a matching ']' before the arrow or newline.
+  [2m┌─ test-fixtures/flowchart/invalid/special-chars.mmd:2:44[0m
+  [2m│[0m
+  2 │     A["Node with quotes"] --> B["Another \"quoted\" node"]
+  [2m│[0m                                            [31m^[0m
+  [2m│[0m
+  help: Example: A[Label] --> B
 ```
 
 <details>
@@ -802,14 +801,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/flowchart/invalid/unclosed-bracket.mmd:
-
-[31merror[0m: test-fixtures/flowchart/invalid/unclosed-bracket.mmd:2:13 [FL-NODE-UNCLOSED-BRACKET] - Unclosed '['. Add a matching ']' before the arrow or newline.
-        hint: Example: A[Label] --> B
-        1 | flowchart LR
-        2 |     A[Start --> B
-          |             ^
-        3 |     B --> C
+[31merror[0m[FL-NODE-UNCLOSED-BRACKET]: Unclosed '['. Add a matching ']' before the arrow or newline.
+  [2m┌─ test-fixtures/flowchart/invalid/unclosed-bracket.mmd:2:13[0m
+  [2m│[0m
+  2 │     A[Start --> B
+  [2m│[0m             [31m^[0m
+  [2m│[0m
+  help: Example: A[Label] --> B
 ```
 
 <details>
@@ -863,13 +861,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/flowchart/invalid/unmatched-end.mmd:
-
-[31merror[0m: test-fixtures/flowchart/invalid/unmatched-end.mmd:3:5 [FL-END-WITHOUT-SUBGRAPH] - 'end' without a matching 'subgraph'.
-        hint: Remove this end or add a subgraph above.
-        2 |     A --> B
-        3 |     end
-          |     ^
+[31merror[0m[FL-END-WITHOUT-SUBGRAPH]: 'end' without a matching 'subgraph'.
+  [2m┌─ test-fixtures/flowchart/invalid/unmatched-end.mmd:3:5[0m
+  [2m│[0m
+  3 │     end
+  [2m│[0m     [31m^^^[0m
+  [2m│[0m
+  help: Remove this end or add a subgraph above.
 ```
 
 <details>
@@ -884,7 +882,97 @@ flowchart TD
 
 ---
 
-## 15. Wrong Direction
+## 15. Unquoted Label With Quotes
+
+📄 **Source**: [`unquoted-label-with-quotes.mmd`](./invalid/unquoted-label-with-quotes.mmd)
+
+❌ **Error**: Label contains double quotes without quoting the whole label. Wrap the entire label in quotes or use &quot; for inner quotes.
+
+### GitHub Render Attempt
+
+> **Note**: This invalid diagram may not render or may render incorrectly.
+
+```mermaid
+flowchart TD
+    A[Application Start] --> B{Check for --debug flag or VISOR_DEBUG env var};
+    B -- Yes --> C[Configure Logger: Level = DEBUG];
+    B -- No --> D[Configure Logger: Level = INFO];
+    
+    subgraph "Runtime Execution"
+        E[Component e.g., CheckExecutionEngine] --> F[Calls logger.debug("message", data)];
+        F --> G{Logger: Is current level DEBUG?};
+        G -- Yes --> H[Format and write message to stderr];
+        G -- No --> I[Discard message];
+    end
+
+    C --> E;
+    D --> E;
+    H --> J[End];
+    I --> J[End];
+
+
+```
+
+### mermaid-cli Result: INVALID
+
+```
+Error: Parse error on line 7:
+...F[Calls logger.debug("message", data)];
+-----------------------^
+Expecting 'SQE', 'DOUBLECIRCLEEND', 'PE', '-)', 'STADIUMEND', 'SUBROUTINEEND', 'PIPE', 'CYLINDEREND', 'DIAMOND_STOP', 'TAGEND', 'TRAPEND', 'INVTRAPEND', 'UNICODE_TEXT', 'TEXT', 'TAGSTART', got 'PS'
+Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
+    at #evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:388:19)
+    at async ExecutionContext.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:275:16)
+    at async IsolatedWorld.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/cdp/IsolatedWorld.js:97:16)
+    at async CdpJSHandle.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/api/JSHandle.js:146:20)
+    at async CdpElementHandle.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/api/ElementHandle.js:340:20)
+    at async CdpElementHandle.$eval (node_modules/puppeteer-core/lib/esm/puppeteer/api/ElementHandle.js:494:24)
+    at async CdpFrame.$eval (node_modules/puppeteer-core/lib/esm/puppeteer/api/Frame.js:450:20)
+    at async CdpPage.$eval (node_modules/puppeteer-core/lib/esm/puppeteer/api/Page.js:450:20)
+    at async renderMermaid (node_modules/@mermaid-js/mermaid-cli/src/index.js:266:22)
+    at fromText (node_modules/mermaid/dist/mermaid.js:153955:21)
+```
+
+### mermaid-lint Result: INVALID
+
+```
+[31merror[0m[FL-NODE-UNCLOSED-BRACKET]: Unclosed '{'. Add a matching '}'.
+  [2m┌─ test-fixtures/flowchart/invalid/unquoted-label-with-quotes.mmd:2:42[0m
+  [2m│[0m
+   2 │     A[Application Start] --> B{Check for --debug flag or VISOR_DEBUG env var};
+  [2m│[0m                                          [31m^[0m
+  [2m│[0m
+  help: Example: C{Decision}
+```
+
+<details>
+<summary>View source code</summary>
+
+```
+flowchart TD
+    A[Application Start] --> B{Check for --debug flag or VISOR_DEBUG env var};
+    B -- Yes --> C[Configure Logger: Level = DEBUG];
+    B -- No --> D[Configure Logger: Level = INFO];
+    
+    subgraph "Runtime Execution"
+        E[Component e.g., CheckExecutionEngine] --> F[Calls logger.debug("message", data)];
+        F --> G{Logger: Is current level DEBUG?};
+        G -- Yes --> H[Format and write message to stderr];
+        G -- No --> I[Discard message];
+    end
+
+    C --> E;
+    D --> E;
+    H --> J[End];
+    I --> J[End];
+
+
+```
+</details>
+
+---
+
+## 16. Wrong Direction
 
 📄 **Source**: [`wrong-direction.mmd`](./invalid/wrong-direction.mmd)
 
@@ -921,13 +1009,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/flowchart/invalid/wrong-direction.mmd:
-
-[31merror[0m: test-fixtures/flowchart/invalid/wrong-direction.mmd:1:11 [FL-DIR-INVALID] - Invalid direction 'XY'. Use one of: TD, TB, BT, RL, LR.
-        hint: Try 'TD' (top-down) or 'LR' (left-to-right).
-        1 | flowchart XY
-          |           ^
-        2 |     A --> B
+[31merror[0m[FL-DIR-INVALID]: Invalid direction 'XY'. Use one of: TD, TB, BT, RL, LR.
+  [2m┌─ test-fixtures/flowchart/invalid/wrong-direction.mmd:1:11[0m
+  [2m│[0m
+  1 │ flowchart XY
+  [2m│[0m           [31m^^[0m
+  [2m│[0m
+  help: Try 'TD' (top-down) or 'LR' (left-to-right).
 ```
 
 <details>

--- a/test-fixtures/flowchart/INVALID_DIAGRAMS.md
+++ b/test-fixtures/flowchart/INVALID_DIAGRAMS.md
@@ -675,8 +675,8 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ```
 Found 1 error(s) in test-fixtures/flowchart/invalid/quotes-double-inside-single.mmd:
 
-[31merror[0m: test-fixtures/flowchart/invalid/quotes-double-inside-single.mmd:2:5 [FL-LABEL-DOUBLE-IN-SINGLE] - Double quotes inside a single-quoted label are not supported by Mermaid. Use double-quoted label or replace " with &quot;.
-        hint: Change to "She said "Hello"" or replace inner " with &quot;.
+[31merror[0m: test-fixtures/flowchart/invalid/quotes-double-inside-single.mmd:2:5 [FL-LABEL-DOUBLE-IN-SINGLE] - Double quotes inside a single-quoted label are not supported by Mermaid. Replace inner " with &quot; or use a double-quoted label with &quot;.
+        hint: Change to "She said &quot;Hello&quot;" or replace inner " with &quot;.
         1 | flowchart LR
         2 |   A['She said "Hello"'] --> B
           |     ^

--- a/test-fixtures/flowchart/INVALID_DIAGRAMS.md
+++ b/test-fixtures/flowchart/INVALID_DIAGRAMS.md
@@ -936,13 +936,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### mermaid-lint Result: INVALID
 
 ```
-[31merror[0m[FL-NODE-UNCLOSED-BRACKET]: Unclosed '{'. Add a matching '}'.
-  [2m┌─ test-fixtures/flowchart/invalid/unquoted-label-with-quotes.mmd:2:42[0m
+[31merror[0m[FL-SUBGRAPH-MISSING-HEADER]: Subgraph header is missing. Add an ID or a [Title] after the keyword.
+  [2m┌─ test-fixtures/flowchart/invalid/unquoted-label-with-quotes.mmd:6:14[0m
   [2m│[0m
-   2 │     A[Application Start] --> B{Check for --debug flag or VISOR_DEBUG env var};
-  [2m│[0m                                          [31m^[0m
+   6 │     subgraph "Runtime Execution"
+  [2m│[0m              [31m^^^^^^^^^^^^^^^^^^^[0m
   [2m│[0m
-  help: Example: C{Decision}
+  help: Example: subgraph API [API Layer]
 ```
 
 <details>

--- a/test-fixtures/flowchart/INVALID_DIAGRAMS.md
+++ b/test-fixtures/flowchart/INVALID_DIAGRAMS.md
@@ -118,10 +118,21 @@ Found 3 error(s) in test-fixtures/flowchart/invalid/empty-nodes.mmd:
 
 [31merror[0m: test-fixtures/flowchart/invalid/empty-nodes.mmd:2:7 [FL-NODE-EMPTY] - Empty node content is not allowed. Label cannot be just empty quotes.
         hint: Use non-empty quoted text, e.g. "Start" or remove the quotes.
+        1 | flowchart TD
+        2 |     A[""] --> B[" "]
+          |       ^
+        3 |     B --> C[]
 [31merror[0m: test-fixtures/flowchart/invalid/empty-nodes.mmd:2:17 [FL-NODE-EMPTY] - Empty node content is not allowed. Label cannot be just empty quotes.
         hint: Use non-empty quoted text, e.g. "Start" or remove the quotes.
+        1 | flowchart TD
+        2 |     A[""] --> B[" "]
+          |                 ^
+        3 |     B --> C[]
 [31merror[0m: test-fixtures/flowchart/invalid/empty-nodes.mmd:3:12 [FL-NODE-EMPTY] - Empty node content is not allowed. Add a label inside the shape.
         hint: Put some text inside [], (), {}, etc. For example: A[Start]
+        2 |     A[""] --> B[" "]
+        3 |     B --> C[]
+          |            ^
 ```
 
 <details>
@@ -181,7 +192,12 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ```
 Found 1 error(s) in test-fixtures/flowchart/invalid/escaped-quotes-in-decision.mmd:
 
-[31merror[0m: test-fixtures/flowchart/invalid/escaped-quotes-in-decision.mmd:6:30 - Expecting token of type --> DiamondClose <-- but found --> 'Driver' <--
+[31merror[0m: test-fixtures/flowchart/invalid/escaped-quotes-in-decision.mmd:6:30 [FL-NODE-UNCLOSED-BRACKET] - Unclosed '{'. Add a matching '}'.
+        hint: Example: C{Decision}
+        5 |         B -- No --> C[Continue with other auth methods]
+        6 |         B -- Yes --> D{"Is \"Driver\" AND \"AuthCheck.Path\" configured?"}
+          |                              ^
+        7 |     end
 ```
 
 <details>
@@ -245,6 +261,10 @@ Found 1 error(s) in test-fixtures/flowchart/invalid/invalid-arrow.mmd:
 
 [31merror[0m: test-fixtures/flowchart/invalid/invalid-arrow.mmd:2:7 [FL-ARROW-INVALID] - Invalid arrow syntax: -> (use --> instead)
         hint: Replace -> with -->, or use -- text --> for inline labels.
+        1 | flowchart TD
+        2 |     A -> B
+          |       ^
+        3 |     B --> C
 ```
 
 <details>
@@ -300,7 +320,11 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ```
 Found 1 error(s) in test-fixtures/flowchart/invalid/invalid-class.mmd:
 
-[31merror[0m: test-fixtures/flowchart/invalid/invalid-class.mmd:NaN:NaN - Expecting token of type --> Identifier <-- but found --> '' <--
+[31merror[0m: test-fixtures/flowchart/invalid/invalid-class.mmd:3:12 [FL-CLASS-MALFORMED] - Invalid class statement. Provide node id(s) then a class name.
+        hint: Example: class A,B important
+        2 |     A --> B
+        3 |     class A
+          |            ^
 ```
 
 <details>
@@ -356,7 +380,12 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ```
 Found 1 error(s) in test-fixtures/flowchart/invalid/invalid-node-syntax.mmd:
 
-[31merror[0m: test-fixtures/flowchart/invalid/invalid-node-syntax.mmd:2:9 - Expecting token of type --> DoubleRoundClose <-- but found --> '-->' <--
+[31merror[0m: test-fixtures/flowchart/invalid/invalid-node-syntax.mmd:2:9 [FL-NODE-UNCLOSED-BRACKET] - Unclosed '(( '. Add a matching '))'.
+        hint: Example: A((Circle))
+        1 | flowchart TD
+        2 |     A(( --> B
+          |         ^
+        3 |     B --> C
 ```
 
 <details>
@@ -410,11 +439,12 @@ FlowDB.addSubGraph (node_modules/mermaid/dist/mermaid.js:45974:26)
 ```
 Found 1 error(s) in test-fixtures/flowchart/invalid/invalid-subgraph.mmd:
 
-[31merror[0m: test-fixtures/flowchart/invalid/invalid-subgraph.mmd:2:13 - Expecting: one of these possible Token sequences:
-  1. [Identifier]
-  2. [SquareOpen]
-but found: '
-'
+[31merror[0m: test-fixtures/flowchart/invalid/invalid-subgraph.mmd:2:13 [FL-SUBGRAPH-MISSING-HEADER] - Subgraph header is missing. Add an ID or a [Title] after the keyword.
+        hint: Example: subgraph API [API Layer]
+        1 | flowchart TD
+        2 |     subgraph
+          |             ^
+        3 |         A --> B
 ```
 
 <details>
@@ -470,10 +500,11 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ```
 Found 1 error(s) in test-fixtures/flowchart/invalid/missing-arrow.mmd:
 
-[31merror[0m: test-fixtures/flowchart/invalid/missing-arrow.mmd:2:7 - Expecting: one of these possible Token sequences:
-  1. [Newline]
-  2. [EOF]
-but found: 'B'
+[31merror[0m: test-fixtures/flowchart/invalid/missing-arrow.mmd:2:7 [FL-LINK-MISSING] - Two nodes on one line must be connected with an arrow before 'B'.
+        hint: Insert --> between nodes, e.g., A --> B.
+        1 | flowchart TD
+        2 |     A B
+          |       ^
 ```
 
 <details>
@@ -528,7 +559,12 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ```
 Found 1 error(s) in test-fixtures/flowchart/invalid/mixed-brackets.mmd:
 
-[31merror[0m: test-fixtures/flowchart/invalid/mixed-brackets.mmd:2:23 - Expecting token of type --> RoundClose <-- but found --> ']' <--
+[31merror[0m: test-fixtures/flowchart/invalid/mixed-brackets.mmd:2:23 [FL-NODE-MIXED-BRACKETS] - Mismatched brackets: opened '(' but closed with ']'.
+        hint: Close with ')' or change the opening bracket to '['.
+        1 | flowchart LR
+        2 |     A[Text] --> B(Text]
+          |                       ^
+        3 |     B --> C
 ```
 
 <details>
@@ -581,7 +617,11 @@ detectType (node_modules/mermaid/dist/mermaid.js:20437:15)
 ```
 Found 1 error(s) in test-fixtures/flowchart/invalid/no-diagram-type.mmd:
 
-[31merror[0m: test-fixtures/flowchart/invalid/no-diagram-type.mmd:1:1 - Diagram must start with "graph", "flowchart", or "pie"
+[31merror[0m: test-fixtures/flowchart/invalid/no-diagram-type.mmd:1:1 [GEN-HEADER-INVALID] - Diagram must start with "graph", "flowchart", or "pie"
+        hint: Start your diagram with e.g. "flowchart TD" or "pie".
+        1 | A --> B
+          | ^
+        2 | B --> C
 ```
 
 <details>
@@ -637,6 +677,10 @@ Found 1 error(s) in test-fixtures/flowchart/invalid/quotes-double-inside-single.
 
 [31merror[0m: test-fixtures/flowchart/invalid/quotes-double-inside-single.mmd:2:5 [FL-LABEL-DOUBLE-IN-SINGLE] - Double quotes inside a single-quoted label are not supported by Mermaid. Use double-quoted label or replace " with &quot;.
         hint: Change to "She said "Hello"" or replace inner " with &quot;.
+        1 | flowchart LR
+        2 |   A['She said "Hello"'] --> B
+          |     ^
+        3 |
 ```
 
 <details>
@@ -696,7 +740,12 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ```
 Found 1 error(s) in test-fixtures/flowchart/invalid/special-chars.mmd:
 
-[31merror[0m: test-fixtures/flowchart/invalid/special-chars.mmd:2:44 - Expecting token of type --> SquareClose <-- but found --> 'quoted' <--
+[31merror[0m: test-fixtures/flowchart/invalid/special-chars.mmd:2:44 [FL-NODE-UNCLOSED-BRACKET] - Unclosed '['. Add a matching ']' before the arrow or newline.
+        hint: Example: A[Label] --> B
+        1 | flowchart LR
+        2 |     A["Node with quotes"] --> B["Another \"quoted\" node"]
+          |                                            ^
+        3 |     B --> C[Node with #35; special &amp; chars]
 ```
 
 <details>
@@ -755,7 +804,12 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ```
 Found 1 error(s) in test-fixtures/flowchart/invalid/unclosed-bracket.mmd:
 
-[31merror[0m: test-fixtures/flowchart/invalid/unclosed-bracket.mmd:2:13 - Expecting token of type --> SquareClose <-- but found --> '-->' <--
+[31merror[0m: test-fixtures/flowchart/invalid/unclosed-bracket.mmd:2:13 [FL-NODE-UNCLOSED-BRACKET] - Unclosed '['. Add a matching ']' before the arrow or newline.
+        hint: Example: A[Label] --> B
+        1 | flowchart LR
+        2 |     A[Start --> B
+          |             ^
+        3 |     B --> C
 ```
 
 <details>
@@ -811,7 +865,11 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ```
 Found 1 error(s) in test-fixtures/flowchart/invalid/unmatched-end.mmd:
 
-[31merror[0m: test-fixtures/flowchart/invalid/unmatched-end.mmd:3:5 - Redundant input, expecting EOF but found: end
+[31merror[0m: test-fixtures/flowchart/invalid/unmatched-end.mmd:3:5 [FL-END-WITHOUT-SUBGRAPH] - 'end' without a matching 'subgraph'.
+        hint: Remove this end or add a subgraph above.
+        2 |     A --> B
+        3 |     end
+          |     ^
 ```
 
 <details>
@@ -865,7 +923,11 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ```
 Found 1 error(s) in test-fixtures/flowchart/invalid/wrong-direction.mmd:
 
-[31merror[0m: test-fixtures/flowchart/invalid/wrong-direction.mmd:1:11 - Expecting token of type --> Direction <-- but found --> 'XY' <--
+[31merror[0m: test-fixtures/flowchart/invalid/wrong-direction.mmd:1:11 [FL-DIR-INVALID] - Invalid direction 'XY'. Use one of: TD, TB, BT, RL, LR.
+        hint: Try 'TD' (top-down) or 'LR' (left-to-right).
+        1 | flowchart XY
+          |           ^
+        2 |     A --> B
 ```
 
 <details>

--- a/test-fixtures/flowchart/invalid/unquoted-label-with-quotes.mmd
+++ b/test-fixtures/flowchart/invalid/unquoted-label-with-quotes.mmd
@@ -1,0 +1,17 @@
+flowchart TD
+    A[Application Start] --> B{Check for --debug flag or VISOR_DEBUG env var};
+    B -- Yes --> C[Configure Logger: Level = DEBUG];
+    B -- No --> D[Configure Logger: Level = INFO];
+    
+    subgraph "Runtime Execution"
+        E[Component e.g., CheckExecutionEngine] --> F[Calls logger.debug("message", data)];
+        F --> G{Logger: Is current level DEBUG?};
+        G -- Yes --> H[Format and write message to stderr];
+        G -- No --> I[Discard message];
+    end
+
+    C --> E;
+    D --> E;
+    H --> J[End];
+    I --> J[End];
+

--- a/test-fixtures/pie/INVALID_DIAGRAMS.md
+++ b/test-fixtures/pie/INVALID_DIAGRAMS.md
@@ -55,14 +55,13 @@ Syntax error in text
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/pie/invalid/colon-only.mmd:
-
-[31merror[0m: test-fixtures/pie/invalid/colon-only.mmd:2:3 [PI-LABEL-REQUIRES-QUOTES] - Slice labels must be quoted (single or double quotes).
-        hint: Example: "Dogs" : 10
-        1 | pie
-        2 |   :
-          |   ^
-        3 |
+[31merror[0m[PI-LABEL-REQUIRES-QUOTES]: Slice labels must be quoted (single or double quotes).
+  [2m┌─ test-fixtures/pie/invalid/colon-only.mmd:2:3[0m
+  [2m│[0m
+  2 │   :
+  [2m│[0m   [31m^[0m
+  [2m│[0m
+  help: Example: "Dogs" : 10
 ```
 
 <details>
@@ -102,13 +101,13 @@ Syntax error in text
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/pie/invalid/invalid-header.mmd:
-
-[31merror[0m: test-fixtures/pie/invalid/invalid-header.mmd:1:1 [GEN-HEADER-INVALID] - Diagram must start with "graph", "flowchart", or "pie"
-        hint: Start your diagram with e.g. "flowchart TD" or "pie".
-        1 | piee
-          | ^
-        2 |   "Dogs" : 10
+[31merror[0m[GEN-HEADER-INVALID]: Diagram must start with "graph", "flowchart", or "pie"
+  [2m┌─ test-fixtures/pie/invalid/invalid-header.mmd:1:1[0m
+  [2m│[0m
+  1 │ piee
+  [2m│[0m [31m^[0m
+  [2m│[0m
+  help: Start your diagram with e.g. "flowchart TD" or "pie".
 ```
 
 <details>
@@ -148,14 +147,13 @@ Syntax error in text
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/pie/invalid/missing-colon.mmd:
-
-[31merror[0m: test-fixtures/pie/invalid/missing-colon.mmd:3:10 [PI-MISSING-COLON] - Missing colon between slice label and value.
-        hint: Use: "Label" : 10
-        2 |   title "Pets"
-        3 |   "Dogs" 10
-          |          ^
-        4 |
+[31merror[0m[PI-MISSING-COLON]: Missing colon between slice label and value.
+  [2m┌─ test-fixtures/pie/invalid/missing-colon.mmd:3:10[0m
+  [2m│[0m
+  3 │   "Dogs" 10
+  [2m│[0m          [31m^^[0m
+  [2m│[0m
+  help: Use: "Label" : 10
 ```
 
 <details>
@@ -195,14 +193,13 @@ Syntax error in text
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/pie/invalid/missing-label.mmd:
-
-[31merror[0m: test-fixtures/pie/invalid/missing-label.mmd:2:3 [PI-LABEL-REQUIRES-QUOTES] - Slice labels must be quoted (single or double quotes).
-        hint: Example: "Dogs" : 10
-        1 | pie
-        2 |   : 10
-          |   ^
-        3 |
+[31merror[0m[PI-LABEL-REQUIRES-QUOTES]: Slice labels must be quoted (single or double quotes).
+  [2m┌─ test-fixtures/pie/invalid/missing-label.mmd:2:3[0m
+  [2m│[0m
+  2 │   : 10
+  [2m│[0m   [31m^[0m
+  [2m│[0m
+  help: Example: "Dogs" : 10
 ```
 
 <details>
@@ -242,14 +239,13 @@ Syntax error in text
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/pie/invalid/missing-number.mmd:
-
-[31merror[0m: test-fixtures/pie/invalid/missing-number.mmd:2:11 [PI-MISSING-NUMBER] - Missing numeric value after colon.
-        hint: Use a number like 10 or 42.5
-        1 | pie
-        2 |   "Dogs" :
-          |           ^
-        3 |   "Cats" :
+[31merror[0m[PI-MISSING-NUMBER]: Missing numeric value after colon.
+  [2m┌─ test-fixtures/pie/invalid/missing-number.mmd:2:11[0m
+  [2m│[0m
+  2 │   "Dogs" :
+  [2m│[0m           [31m^[0m
+  [2m│[0m
+  help: Use a number like 10 or 42.5
 ```
 
 <details>
@@ -288,14 +284,13 @@ Syntax error in text
 ### mermaid-lint Result: INVALID
 
 ```
-Found 1 error(s) in test-fixtures/pie/invalid/unclosed-quote.mmd:
-
-[31merror[0m: test-fixtures/pie/invalid/unclosed-quote.mmd:2:3 [PI-QUOTE-UNCLOSED] - Unclosed quote in slice label.
-        hint: Close the quote: "Dogs" : 10
-        1 | pie
-        2 |   "Dogs : 10
-          |   ^
-        3 |
+[31merror[0m[PI-QUOTE-UNCLOSED]: Unclosed quote in slice label.
+  [2m┌─ test-fixtures/pie/invalid/unclosed-quote.mmd:2:3[0m
+  [2m│[0m
+  2 │   "Dogs : 10
+  [2m│[0m   [31m^^^^^^[0m
+  [2m│[0m
+  help: Close the quote: "Dogs" : 10
 ```
 
 <details>

--- a/test-fixtures/pie/INVALID_DIAGRAMS.md
+++ b/test-fixtures/pie/INVALID_DIAGRAMS.md
@@ -57,7 +57,12 @@ Syntax error in text
 ```
 Found 1 error(s) in test-fixtures/pie/invalid/colon-only.mmd:
 
-[31merror[0m: test-fixtures/pie/invalid/colon-only.mmd:2:3 - Redundant input, expecting EOF but found: :
+[31merror[0m: test-fixtures/pie/invalid/colon-only.mmd:2:3 [PI-LABEL-REQUIRES-QUOTES] - Slice labels must be quoted (single or double quotes).
+        hint: Example: "Dogs" : 10
+        1 | pie
+        2 |   :
+          |   ^
+        3 |
 ```
 
 <details>
@@ -99,7 +104,11 @@ Syntax error in text
 ```
 Found 1 error(s) in test-fixtures/pie/invalid/invalid-header.mmd:
 
-[31merror[0m: test-fixtures/pie/invalid/invalid-header.mmd:1:1 - Diagram must start with "graph", "flowchart", or "pie"
+[31merror[0m: test-fixtures/pie/invalid/invalid-header.mmd:1:1 [GEN-HEADER-INVALID] - Diagram must start with "graph", "flowchart", or "pie"
+        hint: Start your diagram with e.g. "flowchart TD" or "pie".
+        1 | piee
+          | ^
+        2 |   "Dogs" : 10
 ```
 
 <details>
@@ -141,7 +150,12 @@ Syntax error in text
 ```
 Found 1 error(s) in test-fixtures/pie/invalid/missing-colon.mmd:
 
-[31merror[0m: test-fixtures/pie/invalid/missing-colon.mmd:3:10 - Expecting token of type --> Colon <-- but found --> '10' <--
+[31merror[0m: test-fixtures/pie/invalid/missing-colon.mmd:3:10 [PI-MISSING-COLON] - Missing colon between slice label and value.
+        hint: Use: "Label" : 10
+        2 |   title "Pets"
+        3 |   "Dogs" 10
+          |          ^
+        4 |
 ```
 
 <details>
@@ -183,7 +197,12 @@ Syntax error in text
 ```
 Found 1 error(s) in test-fixtures/pie/invalid/missing-label.mmd:
 
-[31merror[0m: test-fixtures/pie/invalid/missing-label.mmd:2:3 - Redundant input, expecting EOF but found: :
+[31merror[0m: test-fixtures/pie/invalid/missing-label.mmd:2:3 [PI-LABEL-REQUIRES-QUOTES] - Slice labels must be quoted (single or double quotes).
+        hint: Example: "Dogs" : 10
+        1 | pie
+        2 |   : 10
+          |   ^
+        3 |
 ```
 
 <details>
@@ -225,8 +244,12 @@ Syntax error in text
 ```
 Found 1 error(s) in test-fixtures/pie/invalid/missing-number.mmd:
 
-[31merror[0m: test-fixtures/pie/invalid/missing-number.mmd:2:11 - Expecting token of type --> NumberLiteral <-- but found --> '
-' <--
+[31merror[0m: test-fixtures/pie/invalid/missing-number.mmd:2:11 [PI-MISSING-NUMBER] - Missing numeric value after colon.
+        hint: Use a number like 10 or 42.5
+        1 | pie
+        2 |   "Dogs" :
+          |           ^
+        3 |   "Cats" :
 ```
 
 <details>
@@ -267,7 +290,12 @@ Syntax error in text
 ```
 Found 1 error(s) in test-fixtures/pie/invalid/unclosed-quote.mmd:
 
-[31merror[0m: test-fixtures/pie/invalid/unclosed-quote.mmd:2:3 - Redundant input, expecting EOF but found: "Dogs
+[31merror[0m: test-fixtures/pie/invalid/unclosed-quote.mmd:2:3 [PI-QUOTE-UNCLOSED] - Unclosed quote in slice label.
+        hint: Close the quote: "Dogs" : 10
+        1 | pie
+        2 |   "Dogs : 10
+          |   ^
+        3 |
 ```
 
 <details>


### PR DESCRIPTION
## Summary
This PR elevates developer experience and error quality:
- Clear, actionable diagnostics with stable codes and fix hints
- New default human output (caret-underlined snippet style)
- Optional strict mode (`--strict`) to enforce quoted labels
- Shared validation pipeline and diagnostics utilities
- Updated fixtures, previews, and docs to match

## Highlights
- Human output (default)
  - Prints a snippet of the offending line with an underlined span and a help line.
  - Example:
    ```
    error[FL-DIR-INVALID]: Invalid direction 'XY'. Use one of: TD, TB, BT, RL, LR.
      ┌─ path/to/file.mmd:1:11
      │
    1 │ flowchart XY
      │           ^^
      │
      help: Try 'TD' (top-down) or 'LR' (left-to-right).
    ```
- JSON output
  - Still available via `--format json` for editors/CI (no behavior change).
- Strict mode
  - `--strict` (alias `-s`) requires quoted labels inside shapes.
  - New code: `FL-STRICT-LABEL-QUOTES-REQUIRED` with explicit fix guidance.
  - Best-practice warning: `FL-LABEL-PARENS-UNQUOTED` for parentheses in unquoted labels.
  - Existing `FL-LABEL-QUOTE-IN-UNQUOTED` maps cases with `"` inside unquoted labels.
- Error taxonomy (docs/errors.md updated)
  - Flowchart: `FL-DIR-INVALID`, `FL-DIR-MISSING`, `FL-LINK-MISSING`, `FL-NODE-UNCLOSED-BRACKET`,
    `FL-NODE-MIXED-BRACKETS`, `FL-CLASS-MALFORMED`, `FL-SUBGRAPH-MISSING-HEADER`, `FL-END-WITHOUT-SUBGRAPH`,
    `FL-LABEL-ESCAPED-QUOTE`, `FL-LABEL-DOUBLE-IN-SINGLE`, `FL-LABEL-QUOTE-IN-UNQUOTED`, `FL-STRICT-LABEL-QUOTES-REQUIRED`.
  - Pie: `PI-LABEL-REQUIRES-QUOTES`, `PI-MISSING-COLON`, `PI-MISSING-NUMBER`, `PI-QUOTE-UNCLOSED`.
  - General: `GEN-HEADER-INVALID`.
- Shared core and pipeline
  - `src/core/diagnostics.ts`: position coercion, codeframes, parser-error mapping.
  - `src/core/pipeline.ts`: reusable tokenize→parse→map→analyze with hooks.
  - `src/core/format.ts`: human (snippet) and JSON formatters.
  - `src/core/errorBuilder.ts`: helpers to build errors/warnings consistently.
- Parser/semantics improvements
  - Flowchart: accept `;` statement terminators; allow `--`/line tokens inside labels; enforce `direction` keyword inside subgraphs; remove raw lexer stderr noise.
  - Quoting guidance now consistently uses `&quot;` (not `\"`).
- Previews and compare scripts
  - Invalid preview captures exact mermaid-cli errors (including error SVGs) and our messages side-by-side.
  - Previews regenerated; CI “previews” job reflects the new human format and added cases.

## New/Updated Fixtures
- Added: `test-fixtures/flowchart/invalid/unquoted-label-with-quotes.mmd` (example with `("message")` inside `[...]`).
- Flowchart counts: 20 valid • 16 invalid
- Pie counts: 4 valid • 6 invalid

## How to test
```bash
npm run build
# Compare against mermaid-cli
npm run test:compare
npm run test:compare:pie
# Regenerate previews (should be clean on CI)
npm run generate:previews
# Try strict mode
node out/cli.js --strict test-fixtures/flowchart/valid/with-text.mmd
# Human vs JSON
node out/cli.js test-fixtures/flowchart/invalid/wrong-direction.mmd
node out/cli.js --format json test-fixtures/flowchart/invalid/wrong-direction.mmd
```

## Backwards compatibility
- Default validation behavior remains aligned with mermaid-cli; output formatting improved for humans.
- JSON output unchanged; suitable for editor/CI integrations.

## Notes
- If you prefer strict mode to only require quotes when labels contain spaces/punctuation, I can narrow the rule easily. Current behavior: always require quotes for shape labels in strict mode.
