### PR TITLE
fix: add id-token write permission for npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds `id-token: write` permission to the publish job in the release workflow
- Fixes npm publish failure when using `--provenance` flag

## Problem
The npm publish step was failing with:
```
npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
```

## Solution
Added the required permissions block to the publish job to enable provenance attestations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)