### PR TITLE
feat(sequence): restrict box blocks to participant/actor declarations only

### DIFF
--- a/src/core/fixes.ts
+++ b/src/core/fixes.ts
@@ -471,6 +471,21 @@ export function computeFixes(text: string, errors: ValidationError[], level: Fix
       edits.push(replaceRange(text, at(e), e.length ?? 4, 'option'));
       continue;
     }
+    if (is('SE-BOX-EMPTY', e)) {
+      // Convert empty box to rect
+      const lines = text.split(/\r?\n/);
+      const boxIdx = Math.max(0, e.line - 1);
+      const boxLine = lines[boxIdx] || '';
+      // Extract the label from box "Label"
+      const labelMatch = /^\s*box\s+(.+)$/.exec(boxLine);
+      if (labelMatch) {
+        const indent = boxLine.match(/^\s*/)?.[0] || '';
+        // Convert to rect with a light color
+        const newLine = `${indent}rect rgb(240, 240, 255)`;
+        edits.push({ start: { line: e.line, column: 1 }, end: { line: e.line, column: boxLine.length + 1 }, newText: newLine });
+      }
+      continue;
+    }
     if (is('SE-BOX-INVALID-CONTENT', e)) {
       // Move messages, notes, and other invalid content outside the box block
       const lines = text.split(/\r?\n/);

--- a/src/diagrams/sequence/parser.ts
+++ b/src/diagrams/sequence/parser.ts
@@ -313,9 +313,15 @@ export class SequenceParser extends CstParser {
     this.CONSUME(t.BoxKeyword);
     this.OPTION(() => this.SUBRULE(this.lineRemainder));
     this.AT_LEAST_ONE(() => this.CONSUME(t.Newline));
-    this.MANY(() => this.SUBRULE(this.line));
+    this.MANY(() => this.OR([
+      { ALT: () => this.SUBRULE(this.participantDecl) },
+      { ALT: () => this.SUBRULE(this.blankLine) },
+    ]));
     this.CONSUME(t.EndKeyword);
-    this.AT_LEAST_ONE2(() => this.CONSUME2(t.Newline));
+    this.OR2([
+      { ALT: () => this.AT_LEAST_ONE2(() => this.CONSUME2(t.Newline)) },
+      { ALT: () => this.CONSUME2(EOF) }
+    ]);
   });
 
   private lineRemainder = this.RULE('lineRemainder', () => {

--- a/test-fixtures/sequence/INVALID_DIAGRAMS.md
+++ b/test-fixtures/sequence/INVALID_DIAGRAMS.md
@@ -14,17 +14,19 @@ This file contains invalid sequence test fixtures with:
 3. [Autonumber Extraneous](#3-autonumber-extraneous)
 4. [Autonumber Malformed](#4-autonumber-malformed)
 5. [Box Unclosed](#5-box-unclosed)
-6. [Create Malformed](#6-create-malformed)
-7. [Create Missing Name](#7-create-missing-name)
-8. [Critical Else](#8-critical-else)
-9. [Destroy Malformed](#9-destroy-malformed)
-10. [Else Outside Alt](#10-else-outside-alt)
-11. [Missing Colon](#11-missing-colon)
-12. [Note Malformed](#12-note-malformed)
-13. [Option In Par](#13-option-in-par)
-14. [Option Outside Critical](#14-option-outside-critical)
-15. [Unmatched End](#15-unmatched-end)
-16. [Wrong Arrow](#16-wrong-arrow)
+6. [Box With Messages](#6-box-with-messages)
+7. [Box With Notes](#7-box-with-notes)
+8. [Create Malformed](#8-create-malformed)
+9. [Create Missing Name](#9-create-missing-name)
+10. [Critical Else](#10-critical-else)
+11. [Destroy Malformed](#11-destroy-malformed)
+12. [Else Outside Alt](#12-else-outside-alt)
+13. [Missing Colon](#13-missing-colon)
+14. [Note Malformed](#14-note-malformed)
+15. [Option In Par](#15-option-in-par)
+16. [Option Outside Critical](#16-option-outside-critical)
+17. [Unmatched End](#17-unmatched-end)
+18. [Wrong Arrow](#18-wrong-arrow)
 
 ---
 
@@ -37,17 +39,19 @@ This file contains invalid sequence test fixtures with:
 | 3 | [autonumber extraneous](#3-autonumber-extraneous) | INVALID | INVALID | ✅ safe |
 | 4 | [autonumber malformed](#4-autonumber-malformed) | INVALID | INVALID | ✅ all |
 | 5 | [box unclosed](#5-box-unclosed) | INVALID | INVALID | ✅ safe |
-| 6 | [create malformed](#6-create-malformed) | INVALID | INVALID | — |
-| 7 | [create missing name](#7-create-missing-name) | INVALID | INVALID | — |
-| 8 | [critical else](#8-critical-else) | INVALID | INVALID | ✅ safe |
-| 9 | [destroy malformed](#9-destroy-malformed) | INVALID | INVALID | — |
-| 10 | [else outside alt](#10-else-outside-alt) | INVALID | INVALID | — |
-| 11 | [missing colon](#11-missing-colon) | INVALID | INVALID | ✅ safe |
-| 12 | [note malformed](#12-note-malformed) | INVALID | INVALID | ✅ safe |
-| 13 | [option in par](#13-option-in-par) | INVALID | INVALID | — |
-| 14 | [option outside critical](#14-option-outside-critical) | INVALID | INVALID | — |
-| 15 | [unmatched end](#15-unmatched-end) | INVALID | INVALID | — |
-| 16 | [wrong arrow](#16-wrong-arrow) | INVALID | INVALID | — |
+| 6 | [box with messages](#6-box-with-messages) | INVALID | INVALID | ✅ safe |
+| 7 | [box with notes](#7-box-with-notes) | INVALID | INVALID | ✅ safe |
+| 8 | [create malformed](#8-create-malformed) | INVALID | INVALID | — |
+| 9 | [create missing name](#9-create-missing-name) | INVALID | INVALID | — |
+| 10 | [critical else](#10-critical-else) | INVALID | INVALID | ✅ safe |
+| 11 | [destroy malformed](#11-destroy-malformed) | INVALID | INVALID | — |
+| 12 | [else outside alt](#12-else-outside-alt) | INVALID | INVALID | — |
+| 13 | [missing colon](#13-missing-colon) | INVALID | INVALID | ✅ safe |
+| 14 | [note malformed](#14-note-malformed) | INVALID | INVALID | ✅ safe |
+| 15 | [option in par](#15-option-in-par) | INVALID | INVALID | — |
+| 16 | [option outside critical](#16-option-outside-critical) | INVALID | INVALID | — |
+| 17 | [unmatched end](#17-unmatched-end) | INVALID | INVALID | — |
+| 18 | [wrong arrow](#18-wrong-arrow) | INVALID | INVALID | — |
 
 ---
 
@@ -457,7 +461,183 @@ sequenceDiagram
 
 ---
 
-## 6. Create Malformed
+## 6. Box With Messages
+
+📄 **Source**: [`box-with-messages.mmd`](./invalid/box-with-messages.mmd)
+
+### GitHub Render Attempt
+
+> **Note**: This invalid diagram may not render or may render incorrectly.
+
+```mermaid
+sequenceDiagram
+    participant A
+    participant B
+    box "Group"
+        A->>B: message inside box
+    end
+
+```
+
+### mermaid-cli Result: INVALID
+
+```
+Error: Parse error on line 5:
+...box "Group"        A->>B: message insid
+----------------------^
+Expecting 'SPACE', 'NEWLINE', 'end', 'participant', 'participant_actor', 'destroy', got 'ACTOR'
+Parser3.parseError (node_modules/mermaid/dist/mermaid.js:123898:28)
+    at #evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:388:19)
+    at async ExecutionContext.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:275:16)
+    at async IsolatedWorld.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/cdp/IsolatedWorld.js:97:16)
+    at async CdpJSHandle.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/api/JSHandle.js:146:20)
+    at async CdpElementHandle.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/api/ElementHandle.js:340:20)
+    at async CdpElementHandle.$eval (node_modules/puppeteer-core/lib/esm/puppeteer/api/ElementHandle.js:494:24)
+    at async CdpFrame.$eval (node_modules/puppeteer-core/lib/esm/puppeteer/api/Frame.js:450:20)
+    at async CdpPage.$eval (node_modules/puppeteer-core/lib/esm/puppeteer/api/Page.js:450:20)
+    at async renderMermaid (node_modules/@mermaid-js/mermaid-cli/src/index.js:266:22)
+    at fromText (node_modules/mermaid/dist/mermaid.js:153955:21)
+```
+
+### maid Result: INVALID
+
+```
+error[SE-BOX-INVALID-CONTENT]: Box blocks can only contain participant/actor declarations.
+at test-fixtures/sequence/invalid/box-with-messages.mmd:5:9
+  4 |     box "Group"
+  5 |         A->>B: message inside box
+    |         ^
+  6 |     end
+hint: Move messages, notes, and other statements outside the box block.
+  Example:
+  box "Group"
+    participant A
+    participant B
+  end
+  A->>B: Message
+```
+
+### maid Auto-fix (`--fix`) Preview
+
+```mermaid
+sequenceDiagram
+    participant A
+    participant B
+    box "Group"
+    end
+    A->>B: message inside box
+
+```
+
+### maid Auto-fix (`--fix=all`) Preview
+
+Shown above (safe changes applied).
+
+<details>
+<summary>View source code</summary>
+
+```
+sequenceDiagram
+    participant A
+    participant B
+    box "Group"
+        A->>B: message inside box
+    end
+
+```
+</details>
+
+---
+
+## 7. Box With Notes
+
+📄 **Source**: [`box-with-notes.mmd`](./invalid/box-with-notes.mmd)
+
+### GitHub Render Attempt
+
+> **Note**: This invalid diagram may not render or may render incorrectly.
+
+```mermaid
+sequenceDiagram
+    participant A
+    participant B
+    box "Group"
+        Note over A: note inside box
+    end
+
+```
+
+### mermaid-cli Result: INVALID
+
+```
+Error: Parse error on line 5:
+...box "Group"        Note over A: note in
+----------------------^
+Expecting 'SPACE', 'NEWLINE', 'end', 'participant', 'participant_actor', 'destroy', got 'note'
+Parser3.parseError (node_modules/mermaid/dist/mermaid.js:123898:28)
+    at #evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:388:19)
+    at async ExecutionContext.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:275:16)
+    at async IsolatedWorld.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/cdp/IsolatedWorld.js:97:16)
+    at async CdpJSHandle.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/api/JSHandle.js:146:20)
+    at async CdpElementHandle.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/api/ElementHandle.js:340:20)
+    at async CdpElementHandle.$eval (node_modules/puppeteer-core/lib/esm/puppeteer/api/ElementHandle.js:494:24)
+    at async CdpFrame.$eval (node_modules/puppeteer-core/lib/esm/puppeteer/api/Frame.js:450:20)
+    at async CdpPage.$eval (node_modules/puppeteer-core/lib/esm/puppeteer/api/Page.js:450:20)
+    at async renderMermaid (node_modules/@mermaid-js/mermaid-cli/src/index.js:266:22)
+    at fromText (node_modules/mermaid/dist/mermaid.js:153955:21)
+```
+
+### maid Result: INVALID
+
+```
+error[SE-BOX-INVALID-CONTENT]: Box blocks can only contain participant/actor declarations.
+at test-fixtures/sequence/invalid/box-with-notes.mmd:5:9
+  4 |     box "Group"
+  5 |         Note over A: note inside box
+    |         ^^^^
+  6 |     end
+hint: Move messages, notes, and other statements outside the box block.
+  Example:
+  box "Group"
+    participant A
+    participant B
+  end
+  A->>B: Message
+```
+
+### maid Auto-fix (`--fix`) Preview
+
+```mermaid
+sequenceDiagram
+    participant A
+    participant B
+    box "Group"
+    end
+    Note over A: note inside box
+
+```
+
+### maid Auto-fix (`--fix=all`) Preview
+
+Shown above (safe changes applied).
+
+<details>
+<summary>View source code</summary>
+
+```
+sequenceDiagram
+    participant A
+    participant B
+    box "Group"
+        Note over A: note inside box
+    end
+
+```
+</details>
+
+---
+
+## 8. Create Malformed
 
 📄 **Source**: [`create-malformed.mmd`](./invalid/create-malformed.mmd)
 
@@ -531,7 +711,7 @@ sequenceDiagram
 
 ---
 
-## 7. Create Missing Name
+## 9. Create Missing Name
 
 📄 **Source**: [`create-missing-name.mmd`](./invalid/create-missing-name.mmd)
 
@@ -600,7 +780,7 @@ sequenceDiagram
 
 ---
 
-## 8. Critical Else
+## 10. Critical Else
 
 📄 **Source**: [`critical-else.mmd`](./invalid/critical-else.mmd)
 
@@ -695,7 +875,7 @@ sequenceDiagram
 
 ---
 
-## 9. Destroy Malformed
+## 11. Destroy Malformed
 
 📄 **Source**: [`destroy-malformed.mmd`](./invalid/destroy-malformed.mmd)
 
@@ -767,7 +947,7 @@ sequenceDiagram
 
 ---
 
-## 10. Else Outside Alt
+## 12. Else Outside Alt
 
 📄 **Source**: [`else-outside-alt.mmd`](./invalid/else-outside-alt.mmd)
 
@@ -839,7 +1019,7 @@ sequenceDiagram
 
 ---
 
-## 11. Missing Colon
+## 13. Missing Colon
 
 📄 **Source**: [`missing-colon.mmd`](./invalid/missing-colon.mmd)
 
@@ -918,7 +1098,7 @@ sequenceDiagram
 
 ---
 
-## 12. Note Malformed
+## 14. Note Malformed
 
 📄 **Source**: [`note-malformed.mmd`](./invalid/note-malformed.mmd)
 
@@ -997,7 +1177,7 @@ sequenceDiagram
 
 ---
 
-## 13. Option In Par
+## 15. Option In Par
 
 📄 **Source**: [`option-in-par.mmd`](./invalid/option-in-par.mmd)
 
@@ -1077,7 +1257,7 @@ sequenceDiagram
 
 ---
 
-## 14. Option Outside Critical
+## 16. Option Outside Critical
 
 📄 **Source**: [`option-outside-critical.mmd`](./invalid/option-outside-critical.mmd)
 
@@ -1152,7 +1332,7 @@ sequenceDiagram
 
 ---
 
-## 15. Unmatched End
+## 17. Unmatched End
 
 📄 **Source**: [`unmatched-end.mmd`](./invalid/unmatched-end.mmd)
 
@@ -1224,7 +1404,7 @@ sequenceDiagram
 
 ---
 
-## 16. Wrong Arrow
+## 18. Wrong Arrow
 
 📄 **Source**: [`wrong-arrow.mmd`](./invalid/wrong-arrow.mmd)
 

--- a/test-fixtures/sequence/INVALID_DIAGRAMS.md
+++ b/test-fixtures/sequence/INVALID_DIAGRAMS.md
@@ -13,20 +13,21 @@ This file contains invalid sequence test fixtures with:
 2. [And Outside Par](#2-and-outside-par)
 3. [Autonumber Extraneous](#3-autonumber-extraneous)
 4. [Autonumber Malformed](#4-autonumber-malformed)
-5. [Box Unclosed](#5-box-unclosed)
-6. [Box With Messages](#6-box-with-messages)
-7. [Box With Notes](#7-box-with-notes)
-8. [Create Malformed](#8-create-malformed)
-9. [Create Missing Name](#9-create-missing-name)
-10. [Critical Else](#10-critical-else)
-11. [Destroy Malformed](#11-destroy-malformed)
-12. [Else Outside Alt](#12-else-outside-alt)
-13. [Missing Colon](#13-missing-colon)
-14. [Note Malformed](#14-note-malformed)
-15. [Option In Par](#15-option-in-par)
-16. [Option Outside Critical](#16-option-outside-critical)
-17. [Unmatched End](#17-unmatched-end)
-18. [Wrong Arrow](#18-wrong-arrow)
+5. [Box Empty](#5-box-empty)
+6. [Box Unclosed](#6-box-unclosed)
+7. [Box With Messages](#7-box-with-messages)
+8. [Box With Notes](#8-box-with-notes)
+9. [Create Malformed](#9-create-malformed)
+10. [Create Missing Name](#10-create-missing-name)
+11. [Critical Else](#11-critical-else)
+12. [Destroy Malformed](#12-destroy-malformed)
+13. [Else Outside Alt](#13-else-outside-alt)
+14. [Missing Colon](#14-missing-colon)
+15. [Note Malformed](#15-note-malformed)
+16. [Option In Par](#16-option-in-par)
+17. [Option Outside Critical](#17-option-outside-critical)
+18. [Unmatched End](#18-unmatched-end)
+19. [Wrong Arrow](#19-wrong-arrow)
 
 ---
 
@@ -38,20 +39,21 @@ This file contains invalid sequence test fixtures with:
 | 2 | [and outside par](#2-and-outside-par) | INVALID | INVALID | — |
 | 3 | [autonumber extraneous](#3-autonumber-extraneous) | INVALID | INVALID | ✅ safe |
 | 4 | [autonumber malformed](#4-autonumber-malformed) | INVALID | INVALID | ✅ all |
-| 5 | [box unclosed](#5-box-unclosed) | INVALID | INVALID | ✅ safe |
-| 6 | [box with messages](#6-box-with-messages) | INVALID | INVALID | ✅ safe |
-| 7 | [box with notes](#7-box-with-notes) | INVALID | INVALID | ✅ safe |
-| 8 | [create malformed](#8-create-malformed) | INVALID | INVALID | — |
-| 9 | [create missing name](#9-create-missing-name) | INVALID | INVALID | — |
-| 10 | [critical else](#10-critical-else) | INVALID | INVALID | ✅ safe |
-| 11 | [destroy malformed](#11-destroy-malformed) | INVALID | INVALID | — |
-| 12 | [else outside alt](#12-else-outside-alt) | INVALID | INVALID | — |
-| 13 | [missing colon](#13-missing-colon) | INVALID | INVALID | ✅ safe |
-| 14 | [note malformed](#14-note-malformed) | INVALID | INVALID | ✅ safe |
-| 15 | [option in par](#15-option-in-par) | INVALID | INVALID | — |
-| 16 | [option outside critical](#16-option-outside-critical) | INVALID | INVALID | — |
-| 17 | [unmatched end](#17-unmatched-end) | INVALID | INVALID | — |
-| 18 | [wrong arrow](#18-wrong-arrow) | INVALID | INVALID | — |
+| 5 | [box empty](#5-box-empty) | INVALID | INVALID | ✅ safe |
+| 6 | [box unclosed](#6-box-unclosed) | INVALID | INVALID | ✅ safe |
+| 7 | [box with messages](#7-box-with-messages) | INVALID | INVALID | ✅ safe |
+| 8 | [box with notes](#8-box-with-notes) | INVALID | INVALID | ✅ safe |
+| 9 | [create malformed](#9-create-malformed) | INVALID | INVALID | — |
+| 10 | [create missing name](#10-create-missing-name) | INVALID | INVALID | — |
+| 11 | [critical else](#11-critical-else) | INVALID | INVALID | ✅ safe |
+| 12 | [destroy malformed](#12-destroy-malformed) | INVALID | INVALID | — |
+| 13 | [else outside alt](#13-else-outside-alt) | INVALID | INVALID | — |
+| 14 | [missing colon](#14-missing-colon) | INVALID | INVALID | ✅ safe |
+| 15 | [note malformed](#15-note-malformed) | INVALID | INVALID | ✅ safe |
+| 16 | [option in par](#16-option-in-par) | INVALID | INVALID | — |
+| 17 | [option outside critical](#17-option-outside-critical) | INVALID | INVALID | — |
+| 18 | [unmatched end](#18-unmatched-end) | INVALID | INVALID | — |
+| 19 | [wrong arrow](#19-wrong-arrow) | INVALID | INVALID | — |
 
 ---
 
@@ -378,7 +380,96 @@ sequenceDiagram
 
 ---
 
-## 5. Box Unclosed
+## 5. Box Empty
+
+📄 **Source**: [`box-empty.mmd`](./invalid/box-empty.mmd)
+
+### GitHub Render Attempt
+
+> **Note**: This invalid diagram may not render or may render incorrectly.
+
+```mermaid
+sequenceDiagram
+    participant A
+    participant B
+    box "Empty Group"
+        A->>B: message
+        Note over A: note
+    end
+
+```
+
+### mermaid-cli Result: INVALID
+
+```
+Error: Parse error on line 5:
+...mpty Group"        A->>B: message     
+----------------------^
+Expecting 'SPACE', 'NEWLINE', 'end', 'participant', 'participant_actor', 'destroy', got 'ACTOR'
+Parser3.parseError (node_modules/mermaid/dist/mermaid.js:123898:28)
+    at #evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:388:19)
+    at async ExecutionContext.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/cdp/ExecutionContext.js:275:16)
+    at async IsolatedWorld.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/cdp/IsolatedWorld.js:97:16)
+    at async CdpJSHandle.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/api/JSHandle.js:146:20)
+    at async CdpElementHandle.evaluate (node_modules/puppeteer-core/lib/esm/puppeteer/api/ElementHandle.js:340:20)
+    at async CdpElementHandle.$eval (node_modules/puppeteer-core/lib/esm/puppeteer/api/ElementHandle.js:494:24)
+    at async CdpFrame.$eval (node_modules/puppeteer-core/lib/esm/puppeteer/api/Frame.js:450:20)
+    at async CdpPage.$eval (node_modules/puppeteer-core/lib/esm/puppeteer/api/Page.js:450:20)
+    at async renderMermaid (node_modules/@mermaid-js/mermaid-cli/src/index.js:266:22)
+    at fromText (node_modules/mermaid/dist/mermaid.js:153955:21)
+```
+
+### maid Result: INVALID
+
+```
+error[SE-BOX-EMPTY]: Box block has no participant/actor declarations. Use 'rect' to group messages visually.
+at test-fixtures/sequence/invalid/box-empty.mmd:4:1
+  3 |     participant B
+  4 |     box "Empty Group"
+    | ^^^
+  5 |         A->>B: message
+hint: Replace 'box' with 'rect' if you want to group messages:
+  rect rgb(240, 240, 255)
+    A->>B: Message
+    Note over A: Info
+  end
+```
+
+### maid Auto-fix (`--fix`) Preview
+
+```mermaid
+sequenceDiagram
+    participant A
+    participant B
+    rect rgb(240, 240, 255)
+        A->>B: message
+        Note over A: note
+    end
+
+```
+
+### maid Auto-fix (`--fix=all`) Preview
+
+Shown above (safe changes applied).
+
+<details>
+<summary>View source code</summary>
+
+```
+sequenceDiagram
+    participant A
+    participant B
+    box "Empty Group"
+        A->>B: message
+        Note over A: note
+    end
+
+```
+</details>
+
+---
+
+## 6. Box Unclosed
 
 📄 **Source**: [`box-unclosed.mmd`](./invalid/box-unclosed.mmd)
 
@@ -461,7 +552,7 @@ sequenceDiagram
 
 ---
 
-## 6. Box With Messages
+## 7. Box With Messages
 
 📄 **Source**: [`box-with-messages.mmd`](./invalid/box-with-messages.mmd)
 
@@ -474,6 +565,7 @@ sequenceDiagram
     participant A
     participant B
     box "Group"
+        participant C
         A->>B: message inside box
     end
 
@@ -482,8 +574,8 @@ sequenceDiagram
 ### mermaid-cli Result: INVALID
 
 ```
-Error: Parse error on line 5:
-...box "Group"        A->>B: message insid
+Error: Parse error on line 6:
+...rticipant C        A->>B: message insid
 ----------------------^
 Expecting 'SPACE', 'NEWLINE', 'end', 'participant', 'participant_actor', 'destroy', got 'ACTOR'
 Parser3.parseError (node_modules/mermaid/dist/mermaid.js:123898:28)
@@ -503,11 +595,11 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:123898:28)
 
 ```
 error[SE-BOX-INVALID-CONTENT]: Box blocks can only contain participant/actor declarations.
-at test-fixtures/sequence/invalid/box-with-messages.mmd:5:9
-  4 |     box "Group"
-  5 |         A->>B: message inside box
+at test-fixtures/sequence/invalid/box-with-messages.mmd:6:9
+  5 |         participant C
+  6 |         A->>B: message inside box
     |         ^
-  6 |     end
+  7 |     end
 hint: Move messages, notes, and other statements outside the box block.
   Example:
   box "Group"
@@ -524,6 +616,7 @@ sequenceDiagram
     participant A
     participant B
     box "Group"
+        participant C
     end
     A->>B: message inside box
 
@@ -541,6 +634,7 @@ sequenceDiagram
     participant A
     participant B
     box "Group"
+        participant C
         A->>B: message inside box
     end
 
@@ -549,7 +643,7 @@ sequenceDiagram
 
 ---
 
-## 7. Box With Notes
+## 8. Box With Notes
 
 📄 **Source**: [`box-with-notes.mmd`](./invalid/box-with-notes.mmd)
 
@@ -562,6 +656,7 @@ sequenceDiagram
     participant A
     participant B
     box "Group"
+        participant C
         Note over A: note inside box
     end
 
@@ -570,8 +665,8 @@ sequenceDiagram
 ### mermaid-cli Result: INVALID
 
 ```
-Error: Parse error on line 5:
-...box "Group"        Note over A: note in
+Error: Parse error on line 6:
+...rticipant C        Note over A: note in
 ----------------------^
 Expecting 'SPACE', 'NEWLINE', 'end', 'participant', 'participant_actor', 'destroy', got 'note'
 Parser3.parseError (node_modules/mermaid/dist/mermaid.js:123898:28)
@@ -591,11 +686,11 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:123898:28)
 
 ```
 error[SE-BOX-INVALID-CONTENT]: Box blocks can only contain participant/actor declarations.
-at test-fixtures/sequence/invalid/box-with-notes.mmd:5:9
-  4 |     box "Group"
-  5 |         Note over A: note inside box
+at test-fixtures/sequence/invalid/box-with-notes.mmd:6:9
+  5 |         participant C
+  6 |         Note over A: note inside box
     |         ^^^^
-  6 |     end
+  7 |     end
 hint: Move messages, notes, and other statements outside the box block.
   Example:
   box "Group"
@@ -612,6 +707,7 @@ sequenceDiagram
     participant A
     participant B
     box "Group"
+        participant C
     end
     Note over A: note inside box
 
@@ -629,6 +725,7 @@ sequenceDiagram
     participant A
     participant B
     box "Group"
+        participant C
         Note over A: note inside box
     end
 
@@ -637,7 +734,7 @@ sequenceDiagram
 
 ---
 
-## 8. Create Malformed
+## 9. Create Malformed
 
 📄 **Source**: [`create-malformed.mmd`](./invalid/create-malformed.mmd)
 
@@ -711,7 +808,7 @@ sequenceDiagram
 
 ---
 
-## 9. Create Missing Name
+## 10. Create Missing Name
 
 📄 **Source**: [`create-missing-name.mmd`](./invalid/create-missing-name.mmd)
 
@@ -780,7 +877,7 @@ sequenceDiagram
 
 ---
 
-## 10. Critical Else
+## 11. Critical Else
 
 📄 **Source**: [`critical-else.mmd`](./invalid/critical-else.mmd)
 
@@ -875,7 +972,7 @@ sequenceDiagram
 
 ---
 
-## 11. Destroy Malformed
+## 12. Destroy Malformed
 
 📄 **Source**: [`destroy-malformed.mmd`](./invalid/destroy-malformed.mmd)
 
@@ -947,7 +1044,7 @@ sequenceDiagram
 
 ---
 
-## 12. Else Outside Alt
+## 13. Else Outside Alt
 
 📄 **Source**: [`else-outside-alt.mmd`](./invalid/else-outside-alt.mmd)
 
@@ -1019,7 +1116,7 @@ sequenceDiagram
 
 ---
 
-## 13. Missing Colon
+## 14. Missing Colon
 
 📄 **Source**: [`missing-colon.mmd`](./invalid/missing-colon.mmd)
 
@@ -1098,7 +1195,7 @@ sequenceDiagram
 
 ---
 
-## 14. Note Malformed
+## 15. Note Malformed
 
 📄 **Source**: [`note-malformed.mmd`](./invalid/note-malformed.mmd)
 
@@ -1177,7 +1274,7 @@ sequenceDiagram
 
 ---
 
-## 15. Option In Par
+## 16. Option In Par
 
 📄 **Source**: [`option-in-par.mmd`](./invalid/option-in-par.mmd)
 
@@ -1257,7 +1354,7 @@ sequenceDiagram
 
 ---
 
-## 16. Option Outside Critical
+## 17. Option Outside Critical
 
 📄 **Source**: [`option-outside-critical.mmd`](./invalid/option-outside-critical.mmd)
 
@@ -1332,7 +1429,7 @@ sequenceDiagram
 
 ---
 
-## 17. Unmatched End
+## 18. Unmatched End
 
 📄 **Source**: [`unmatched-end.mmd`](./invalid/unmatched-end.mmd)
 
@@ -1404,7 +1501,7 @@ sequenceDiagram
 
 ---
 
-## 18. Wrong Arrow
+## 19. Wrong Arrow
 
 📄 **Source**: [`wrong-arrow.mmd`](./invalid/wrong-arrow.mmd)
 

--- a/test-fixtures/sequence/VALID_DIAGRAMS.md
+++ b/test-fixtures/sequence/VALID_DIAGRAMS.md
@@ -22,15 +22,16 @@ This file contains all valid sequence test fixtures rendered with both Mermaid a
 7. [bidir and async arrows](#7-bidir-and-async-arrows)
 8. [blocks alt opt loop](#8-blocks-alt-opt-loop)
 9. [box groups](#9-box-groups)
-10. [critical break rect](#10-critical-break-rect)
-11. [links and menus](#11-links-and-menus)
-12. [no trailing newline](#12-no-trailing-newline)
-13. [notes](#13-notes)
-14. [par and](#14-par-and)
-15. [par minimal](#15-par-minimal)
-16. [participant double in double](#16-participant-double-in-double)
-17. [participant escaped quotes](#17-participant-escaped-quotes)
-18. [participant unclosed quote](#18-participant-unclosed-quote)
+10. [box with messages outside](#10-box-with-messages-outside)
+11. [critical break rect](#11-critical-break-rect)
+12. [links and menus](#12-links-and-menus)
+13. [no trailing newline](#13-no-trailing-newline)
+14. [notes](#14-notes)
+15. [par and](#15-par-and)
+16. [par minimal](#16-par-minimal)
+17. [participant double in double](#17-participant-double-in-double)
+18. [participant escaped quotes](#18-participant-escaped-quotes)
+19. [participant unclosed quote](#19-participant-unclosed-quote)
 
 ---
 
@@ -533,7 +534,53 @@ sequenceDiagram
 
 ---
 
-## 10. Critical Break Rect
+## 10. Box With Messages Outside
+
+📄 **Source**: [`box-with-messages-outside.mmd`](./valid/box-with-messages-outside.mmd)
+
+### Rendered Output (Mermaid)
+
+```mermaid
+sequenceDiagram
+    box "API Layer"
+        participant Server
+        participant API
+    end
+    box "UI Layer"
+        participant UI
+        participant Component
+    end
+    Server->>API: Request
+    API->>UI: Data
+    UI->>Component: Render
+    Note over API,UI: Communication layer
+
+```
+
+<details>
+<summary>View source code</summary>
+
+```
+sequenceDiagram
+    box "API Layer"
+        participant Server
+        participant API
+    end
+    box "UI Layer"
+        participant UI
+        participant Component
+    end
+    Server->>API: Request
+    API->>UI: Data
+    UI->>Component: Render
+    Note over API,UI: Communication layer
+
+```
+</details>
+
+---
+
+## 11. Critical Break Rect
 
 📄 **Source**: [`critical-break-rect.mmd`](./valid/critical-break-rect.mmd)
 
@@ -598,7 +645,7 @@ sequenceDiagram
 
 ---
 
-## 11. Links And Menus
+## 12. Links And Menus
 
 📄 **Source**: [`links-and-menus.mmd`](./valid/links-and-menus.mmd)
 
@@ -649,7 +696,7 @@ sequenceDiagram
 
 ---
 
-## 12. No Trailing Newline
+## 13. No Trailing Newline
 
 📄 **Source**: [`no-trailing-newline.mmd`](./valid/no-trailing-newline.mmd)
 
@@ -690,7 +737,7 @@ A->>B: hi
 
 ---
 
-## 13. Notes
+## 14. Notes
 
 📄 **Source**: [`notes.mmd`](./valid/notes.mmd)
 
@@ -741,7 +788,7 @@ sequenceDiagram
 
 ---
 
-## 14. Par And
+## 15. Par And
 
 📄 **Source**: [`par-and.mmd`](./valid/par-and.mmd)
 
@@ -796,7 +843,7 @@ sequenceDiagram
 
 ---
 
-## 15. Par Minimal
+## 16. Par Minimal
 
 📄 **Source**: [`par-minimal.mmd`](./valid/par-minimal.mmd)
 
@@ -847,7 +894,7 @@ sequenceDiagram
 
 ---
 
-## 16. Participant Double In Double
+## 17. Participant Double In Double
 
 📄 **Source**: [`participant-double-in-double.mmd`](./valid/participant-double-in-double.mmd)
 
@@ -892,7 +939,7 @@ sequenceDiagram
 
 ---
 
-## 17. Participant Escaped Quotes
+## 18. Participant Escaped Quotes
 
 📄 **Source**: [`participant-escaped-quotes.mmd`](./valid/participant-escaped-quotes.mmd)
 
@@ -937,7 +984,7 @@ sequenceDiagram
 
 ---
 
-## 18. Participant Unclosed Quote
+## 19. Participant Unclosed Quote
 
 📄 **Source**: [`participant-unclosed-quote.mmd`](./valid/participant-unclosed-quote.mmd)
 

--- a/test-fixtures/sequence/VALID_DIAGRAMS.md
+++ b/test-fixtures/sequence/VALID_DIAGRAMS.md
@@ -538,7 +538,15 @@ sequenceDiagram
 
 📄 **Source**: [`box-with-messages-outside.mmd`](./valid/box-with-messages-outside.mmd)
 
-### Rendered Output (Mermaid)
+### Rendered Output
+
+<table>
+<tr>
+<th width="50%">Mermaid (Official)</th>
+<th width="50%">Maid (Experimental)</th>
+</tr>
+<tr>
+<td>
 
 ```mermaid
 sequenceDiagram
@@ -556,6 +564,15 @@ sequenceDiagram
     Note over API,UI: Communication layer
 
 ```
+
+</td>
+<td>
+
+<img src="./rendered/box-with-messages-outside.svg" alt="Maid Rendered Diagram" />
+
+</td>
+</tr>
+</table>
 
 <details>
 <summary>View source code</summary>

--- a/test-fixtures/sequence/expected-errors.json
+++ b/test-fixtures/sequence/expected-errors.json
@@ -8,6 +8,9 @@
   "autonumber-malformed.mmd": [
     "SE-AUTONUMBER-NON-NUMERIC"
   ],
+  "box-empty.mmd": [
+    "SE-BOX-EMPTY"
+  ],
   "box-unclosed.mmd": [
     "SE-BLOCK-MISSING-END"
   ],

--- a/test-fixtures/sequence/expected-errors.json
+++ b/test-fixtures/sequence/expected-errors.json
@@ -11,6 +11,12 @@
   "box-unclosed.mmd": [
     "SE-BLOCK-MISSING-END"
   ],
+  "box-with-messages.mmd": [
+    "SE-BOX-INVALID-CONTENT"
+  ],
+  "box-with-notes.mmd": [
+    "SE-BOX-INVALID-CONTENT"
+  ],
   "create-malformed.mmd": [
     "SE-CREATE-MALFORMED"
   ],

--- a/test-fixtures/sequence/invalid/box-empty.mmd
+++ b/test-fixtures/sequence/invalid/box-empty.mmd
@@ -1,0 +1,7 @@
+sequenceDiagram
+    participant A
+    participant B
+    box "Empty Group"
+        A->>B: message
+        Note over A: note
+    end

--- a/test-fixtures/sequence/invalid/box-with-messages.mmd
+++ b/test-fixtures/sequence/invalid/box-with-messages.mmd
@@ -2,5 +2,6 @@ sequenceDiagram
     participant A
     participant B
     box "Group"
+        participant C
         A->>B: message inside box
     end

--- a/test-fixtures/sequence/invalid/box-with-messages.mmd
+++ b/test-fixtures/sequence/invalid/box-with-messages.mmd
@@ -1,0 +1,6 @@
+sequenceDiagram
+    participant A
+    participant B
+    box "Group"
+        A->>B: message inside box
+    end

--- a/test-fixtures/sequence/invalid/box-with-notes.mmd
+++ b/test-fixtures/sequence/invalid/box-with-notes.mmd
@@ -2,5 +2,6 @@ sequenceDiagram
     participant A
     participant B
     box "Group"
+        participant C
         Note over A: note inside box
     end

--- a/test-fixtures/sequence/invalid/box-with-notes.mmd
+++ b/test-fixtures/sequence/invalid/box-with-notes.mmd
@@ -1,0 +1,6 @@
+sequenceDiagram
+    participant A
+    participant B
+    box "Group"
+        Note over A: note inside box
+    end

--- a/test-fixtures/sequence/rendered/box-with-messages-outside.svg
+++ b/test-fixtures/sequence/rendered/box-with-messages-outside.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="610" height="300" viewBox="-50 -10 610 300">
+<svg xmlns="http://www.w3.org/2000/svg" width="610" height="372" viewBox="-50 -10 610 372">
   <style>
     .node-shape { fill: #eef0ff; stroke: #3f3f3f; stroke-width: 1px; }
     .node-label { fill: #333; font-family: Arial, sans-serif; font-size: 14px; }
@@ -29,19 +29,19 @@
   </style>
   <g class="actor" transform="translate(24,24)">
     <rect class="node-shape" width="110" height="32" rx="0"/>
-    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">A1</text>
+    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">Server</text>
   </g>
   <g class="actor" transform="translate(158,24)">
     <rect class="node-shape" width="110" height="32" rx="0"/>
-    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">B1</text>
+    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">API</text>
   </g>
   <g class="actor" transform="translate(292,24)">
     <rect class="node-shape" width="110" height="32" rx="0"/>
-    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">A2</text>
+    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">UI</text>
   </g>
   <g class="actor" transform="translate(426,24)">
     <rect class="node-shape" width="110" height="32" rx="0"/>
-    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">B2</text>
+    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">Component</text>
   </g>
 <g class="cluster-bg-layer" transform="translate(16,40)">
   <rect class="cluster-bg" x="0" y="0" width="528" height="64" rx="0"/>
@@ -49,42 +49,50 @@
 <g class="cluster-bg-layer" transform="translate(16,76)">
   <rect class="cluster-bg" x="0" y="0" width="528" height="64" rx="0"/>
 </g>
-  <line class="lifeline" x1="79" y1="60" x2="79" y2="204"/>
-  <line class="lifeline" x1="213" y1="60" x2="213" y2="204"/>
-  <line class="lifeline" x1="347" y1="60" x2="347" y2="204"/>
-  <line class="lifeline" x1="481" y1="60" x2="481" y2="204"/>
+  <line class="lifeline" x1="79" y1="60" x2="79" y2="276"/>
+  <line class="lifeline" x1="213" y1="60" x2="213" y2="276"/>
+  <line class="lifeline" x1="347" y1="60" x2="347" y2="276"/>
+  <line class="lifeline" x1="481" y1="60" x2="481" y2="276"/>
   <path class="msg-line solid" d="M 79 150 L 213 150" />
   <path d="M213,150 L205,153 L205,147 Z" fill="#333" />
-  <rect class="msg-label-bg" x="126.5" y="132" width="39" height="16" rx="0"/>
-  <text class="msg-label" x="146" y="140" text-anchor="middle">Sync</text>
-  <path class="msg-line dotted" d="M 347 186 L 481 186" />
-  <path d="M481,186 L473,189 L473,183 Z" fill="#333" />
-  <rect class="msg-label-bg" x="391" y="168" width="46" height="16" rx="0"/>
-  <text class="msg-label" x="414" y="176" text-anchor="middle">Async</text>
+  <rect class="msg-label-bg" x="116" y="132" width="60" height="16" rx="0"/>
+  <text class="msg-label" x="146" y="140" text-anchor="middle">Request</text>
+  <path class="msg-line solid" d="M 213 186 L 347 186" />
+  <path d="M347,186 L339,189 L339,183 Z" fill="#333" />
+  <rect class="msg-label-bg" x="260.5" y="168" width="39" height="16" rx="0"/>
+  <text class="msg-label" x="280" y="176" text-anchor="middle">Data</text>
+  <path class="msg-line solid" d="M 347 222 L 481 222" />
+  <path d="M481,222 L473,225 L473,219 Z" fill="#333" />
+  <rect class="msg-label-bg" x="387.5" y="204" width="53" height="16" rx="0"/>
+  <text class="msg-label" x="414" y="212" text-anchor="middle">Render</text>
+  <g class="note" transform="translate(205,250)">
+    <rect width="150" height="28" rx="0"/>
+    <text class="note-text" x="75" y="18" text-anchor="middle">Communication layer</text>
+  </g>
 <g class="cluster-overlay" transform="translate(16,40)">
 <rect class="cluster-border" x="0" y="0" width="528" height="64" rx="0"/>
-<rect class="cluster-title-bg" x="6" y="-2" width="176" height="18" rx="3"/>
-<text class="cluster-label-text" x="12" y="11" text-anchor="start">box: LightBlue System A</text>
+<rect class="cluster-title-bg" x="6" y="-2" width="111" height="18" rx="3"/>
+<text class="cluster-label-text" x="12" y="11" text-anchor="start">box: API Layer</text>
 </g>
 <g class="cluster-overlay" transform="translate(16,76)">
 <rect class="cluster-border" x="0" y="0" width="528" height="64" rx="0"/>
-<rect class="cluster-title-bg" x="6" y="-2" width="183" height="18" rx="3"/>
-<text class="cluster-label-text" x="12" y="11" text-anchor="start">box: LightGreen System B</text>
+<rect class="cluster-title-bg" x="6" y="-2" width="104" height="18" rx="3"/>
+<text class="cluster-label-text" x="12" y="11" text-anchor="start">box: UI Layer</text>
 </g>
-  <g class="actor" transform="translate(24,204)">
+  <g class="actor" transform="translate(24,276)">
     <rect class="node-shape" width="110" height="32" rx="0"/>
-    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">A1</text>
+    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">Server</text>
   </g>
-  <g class="actor" transform="translate(158,204)">
+  <g class="actor" transform="translate(158,276)">
     <rect class="node-shape" width="110" height="32" rx="0"/>
-    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">B1</text>
+    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">API</text>
   </g>
-  <g class="actor" transform="translate(292,204)">
+  <g class="actor" transform="translate(292,276)">
     <rect class="node-shape" width="110" height="32" rx="0"/>
-    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">A2</text>
+    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">UI</text>
   </g>
-  <g class="actor" transform="translate(426,204)">
+  <g class="actor" transform="translate(426,276)">
     <rect class="node-shape" width="110" height="32" rx="0"/>
-    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">B2</text>
+    <text class="node-label" x="55" y="16" text-anchor="middle" dominant-baseline="middle">Component</text>
   </g>
 </svg>

--- a/test-fixtures/sequence/valid/box-with-messages-outside.mmd
+++ b/test-fixtures/sequence/valid/box-with-messages-outside.mmd
@@ -1,0 +1,13 @@
+sequenceDiagram
+    box "API Layer"
+        participant Server
+        participant API
+    end
+    box "UI Layer"
+        participant UI
+        participant Component
+    end
+    Server->>API: Request
+    API->>UI: Data
+    UI->>Component: Render
+    Note over API,UI: Communication layer


### PR DESCRIPTION
## Summary

Fixes the sequence diagram parser to properly validate `box` blocks according to Mermaid.js specification. Box blocks should only contain `participant` or `actor` declarations, not messages, notes, or other statements.

**New:** Also detects empty boxes (with no participants) and suggests using `rect` instead for visual grouping.

## Changes

### Parser (`src/diagrams/sequence/parser.ts`)
- Modified `boxBlock` rule to only accept `participant`/`actor` declarations and blank lines
- Added proper EOF handling after `end` keyword
- Previously allowed any line type inside boxes (incorrect behavior)

### Error Diagnostics (`src/core/diagnostics.ts`)
- Added `SE-BOX-INVALID-CONTENT` error code for boxes with invalid content
- Added `SE-BOX-EMPTY` error code for boxes with no participants
- Smart detection to differentiate between "missing end" vs "invalid content" vs "empty box"
- Provides helpful examples of correct usage

### Auto-Fix (`src/core/fixes.ts`)
- **Invalid content**: Automatically moves messages/notes outside the box block
- **Empty box**: Converts `box` to `rect rgb(240, 240, 255)` for visual grouping
- Moved content aligns with `end` keyword indentation (not box content indent)

### Test Coverage
- Added `test-fixtures/sequence/invalid/box-empty.mmd`
- Added `test-fixtures/sequence/invalid/box-with-messages.mmd`
- Added `test-fixtures/sequence/invalid/box-with-notes.mmd`
- Added `test-fixtures/sequence/valid/box-with-messages-outside.mmd`
- Updated `expected-errors.json` with new error codes
- All 53 error tests passing

## Examples

### Case 1: Box with Invalid Content (has participants)

**Before (Invalid ❌)**
```mermaid
sequenceDiagram
    box "Group"
        participant A
        A->>B: message inside  ← ERROR
    end
```

**After Auto-Fix (Valid ✅)**
```mermaid
sequenceDiagram
    box "Group"
        participant A
    end
    A->>B: message inside  ← Moved outside
```

### Case 2: Empty Box (no participants)

**Before (Invalid ❌)**
```mermaid
sequenceDiagram
    box "Group"
        A->>B: message  ← ERROR: no participants
    end
```

**After Auto-Fix (Valid ✅)**
```mermaid
sequenceDiagram
    rect rgb(240, 240, 255)
        A->>B: message  ← Use rect for grouping
    end
```

## Testing

```bash
npm run test:errors:sequence  # ✅ 19 passed, 0 failed
npm run test:errors:all       # ✅ 53 passed, 0 failed
```

## Related Discussion

This addresses the common confusion where users try to use `box` for visual grouping of messages, when they should use `rect` instead. The `box` keyword is specifically for grouping participant declarations at the top of the diagram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>