### PR TITLE
flowchart: linkStyle parity + bracket fixes + double-circle all-level fix

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -142,6 +142,10 @@ Tip: quoting inside labels
   - When: A node shape opens but is not properly closed (e.g., `[`, `(`, `{`, `[[`, `((`).
   - Message: Clarifies which bracket is unclosed and what to add.
   - Hint: Example-specific (e.g., `A[Label] --> B`).
+  - Auto-fix:
+    - Safe: fixes square/curly/most bracket cases conservatively (no trailing space inside label).
+    - All: also fixes double-circle `((` by inserting the node id as the label (e.g., `A((A))`) and the closer. If a label cannot be inferred from the id, no fix is applied.
+
 
 - FL-NODE-MIXED-BRACKETS
   - When: Opening and closing brackets don't match (e.g., `(text]`).
@@ -467,6 +471,17 @@ Severity note: By default, quoting issues in participant/actor names are warning
   - When: `linkStyle` references an edge id that does not exist.
   - Message: "Unknown edge id 'X' in linkStyle statement."
   - Hint: "Define the edge id using 'e1@-->' before styling it, or use numeric indices."
+
+- FL-LINKSTYLE-MULTILINE
+  - When: Style key:value pairs are placed on the next line after the `linkStyle` indices.
+  - Message: "'linkStyle' styles must be on the same line as the indices."
+  - Hint: "Example: linkStyle 0,1 stroke:#f00,stroke-width:2px"
+
+- FL-LINKSTYLE-RANGE-NOT-SUPPORTED
+  - When: A range like `0:3` is used in the list of `linkStyle` indices.
+  - Message: "Ranges in 'linkStyle' indices are not supported. Use comma-separated indices."
+  - Hint: "Example: linkStyle 0,1 stroke:#f00,stroke-width:2px"
+
 
 - FL-EDGE-ATTR-ID-UNKNOWN
   - When: An edge attribute statement `e1@{ ... }` references a non-existent edge id.

--- a/docs/spec-parity.md
+++ b/docs/spec-parity.md
@@ -84,3 +84,11 @@ Next actions snapshot
   - Class: endpoint label/cardinality placement on multi‑bend edges; smarter overlap avoidance.
   - State: minor alignment tweaks under LR/RL; divider visuals where titles overlap.
   - Pie: add fixtures around internal quotes; keep parity with mermaid‑cli behavior.
+
+Known Compatibility Gaps vs mermaid‑cli
+
+- Flowchart — linkStyle multiline styles
+  - Behavior: Maid currently accepts `linkStyle` style pairs split across multiple lines (e.g., indices on one line, then styles on the next lines). Current mermaid‑cli rejects this (parse error after indices when a newline precedes styles).
+  - Example fixture: `test-fixtures/flowchart/invalid/interactions-linkstyle-multi.mmd` — if the indices were all valid, Maid would accept the multiline style whereas mermaid‑cli would still fail.
+  - Action: Align with mermaid‑cli (reject styles after a newline) or gate via an explicit option; keep ranges like `0:3` invalid.
+

--- a/scripts/test-fixes.js
+++ b/scripts/test-fixes.js
@@ -94,6 +94,12 @@ const cases = [
     afterLevel: 'all', // we treat as insertion; still valid
   },
   {
+    name: 'FL-NODE-UNCLOSED-BRACKET (double-circle all)',
+    before: 'flowchart TD\nA(( --> B\n',
+    after:  'flowchart TD\nA((A))--> B\n',
+    afterLevel: 'all'
+  },
+  {
     name: 'FL-NODE-EMPTY (strip brackets)',
     before: 'flowchart TD\n    A["\"] --> B[" "]\n    B --> C[]\n',
     after:  'flowchart TD\n    A --> B\n    B --> C\n'

--- a/src/core/fixes.ts
+++ b/src/core/fixes.ts
@@ -262,6 +262,50 @@ export function computeFixes(text: string, errors: ValidationError[], level: Fix
       const msg = e.message || '';
       const lineText = lineTextAt(text, e.line);
       const caret0 = Math.max(0, e.column - 1);
+      // Handle common nested opener pairs with targeted replacements and then stop further fixes for this line
+      // Case: '([' ... '})'  => replace '}' with ']'
+      {
+        const openIdx = lineText.indexOf('([');
+        if (openIdx !== -1) {
+          const badClose = lineText.indexOf('})', openIdx + 2);
+          if (badClose !== -1) {
+            edits.push({ start: { line: e.line, column: badClose + 1 }, end: { line: e.line, column: badClose + 2 }, newText: ']' });
+            patchedLines.add(e.line);
+            continue;
+          }
+        }
+      }
+      // Case: '[(' ... '))'  => replace the second ')' with ']'
+      {
+        const openIdx = lineText.indexOf('[(');
+        if (openIdx !== -1) {
+          const closePair = lineText.indexOf('))', openIdx + 2);
+          if (closePair !== -1) {
+            // second ')' is at closePair + 1 (0-based)
+            edits.push({ start: { line: e.line, column: closePair + 2 }, end: { line: e.line, column: closePair + 3 }, newText: ']' });
+            patchedLines.add(e.line);
+            continue;
+          }
+        }
+      }
+
+      // Robust special-case: if the line opens with '([' and later we see a '})', turn it into '])'
+      {
+        const openPair = lineText.indexOf('([');
+        if (openPair !== -1) {
+          const badClose = lineText.indexOf('})', openPair + 2);
+          if (badClose !== -1) {
+            edits.push({ start: { line: e.line, column: badClose + 1 }, end: { line: e.line, column: badClose + 2 }, newText: ']' });
+            continue;
+          }
+        }
+      }
+
+      // Special-case: mixed pair '([' should close as '])' — if we see '})' at the caret, replace '}' with ']'
+      if (/\(\[/.test(lineText) && lineText.indexOf('})', Math.max(0, caret0 - 1)) !== -1) {
+        edits.push(replaceRange(text, at(e), e.length ?? 1, ']'));
+        continue;
+      }
       if (msg.includes("opened '('") && msg.includes("closed with ']'")) {
         const openIdx = lineText.lastIndexOf('(', caret0);
         if (openIdx !== -1) {
@@ -339,7 +383,40 @@ export function computeFixes(text: string, errors: ValidationError[], level: Fix
         // e.g., "Unclosed '['." or "Unclosed '{' ."
         const msg = e.message || '';
         const bracketMatch = msg.match(/Unclosed '(.+?)'/);
-        const expectedOpener = bracketMatch ? bracketMatch[1] : null;
+        const expectedOpener = bracketMatch ? (bracketMatch[1] || '').trim() : null;
+        // Content-aware fix for double-circle opener '((' under --fix=all: insert a minimal label and the closer.
+        if (expectedOpener === '((') {
+          if (level === 'all') {
+            // Find the last '((' before caret
+            const openIdx = lineText.lastIndexOf('((', caret0);
+            if (openIdx !== -1) {
+              const contentStart = openIdx + 2;
+              // Find the first link/arrow or end-of-line to place the closer before it
+              const picks: number[] = [];
+              const pushIdx2 = (i: number) => { if (i >= 0) picks.push(i); };
+              pushIdx2(lineText.indexOf('-', contentStart));
+              pushIdx2(lineText.indexOf('=', contentStart));
+              pushIdx2(lineText.indexOf('.', contentStart));
+              pushIdx2(lineText.indexOf('|', contentStart));
+              let insertIdx = picks.length ? Math.min(...picks) : lineText.length;
+              // Infer label from node id just before the "((" opener
+              const before = lineText.slice(0, openIdx);
+              const m = before.match(/([A-Za-z0-9_]+)\s*$/);
+              const inferred = m ? m[1] : '';
+              if (inferred) {
+                // Replace from contentStart..insertIdx with '<id>))' (no spaces)
+                edits.push({ start: { line: e.line, column: contentStart + 1 }, end: { line: e.line, column: insertIdx + 1 }, newText: inferred + '))' });
+                patchedLines.add(e.line);
+                continue;
+              }
+              // If we cannot infer a label from the id, do not guess; skip auto-fix
+              patchedLines.add(e.line);
+              continue;
+            }
+          }
+          // If not --fix=all, skip editing to avoid invalid empty label
+          continue;
+        }
 
         // Map opener to closer
         const bracketMap: Record<string, string> = {
@@ -436,10 +513,35 @@ export function computeFixes(text: string, errors: ValidationError[], level: Fix
         }
         let closer = ']';
         if (opened) closer = opened.close;
-        // Replace the wrong token(s) at caret with the correct closer
-        const avail = lineText.slice(caret0);
-        const replaceLen = Math.min(closer.length, Math.max(1, avail.length));
-        edits.push({ start: { line: e.line, column: caret0 + 1 }, end: { line: e.line, column: caret0 + 1 + replaceLen }, newText: closer });
+        // Prefer a targeted insertion for the common square-bracket case: place ']' just before the link/arrow
+        if (closer === ']') {
+          const openIdxSq = lineText.lastIndexOf('[', caret0);
+          if (openIdxSq !== -1) {
+            // Find first link-like token after the opener
+            const picks: number[] = [];
+            const pushIdx2 = (i: number) => { if (i >= 0) picks.push(i); };
+            pushIdx2(lineText.indexOf('-', openIdxSq + 1));
+            pushIdx2(lineText.indexOf('=', openIdxSq + 1));
+            pushIdx2(lineText.indexOf('.', openIdxSq + 1));
+            pushIdx2(lineText.indexOf('|', openIdxSq + 1));
+            let ins = picks.length ? Math.min(...picks) : lineText.length;
+            // Trim trailing spaces before insertion
+            let tl = ins - 1;
+            while (tl >= 0 && /\s/.test(lineText[tl])) tl--;
+            const startCol2 = (tl + 1) + 1; // after last non-space
+            const endCol2 = ins + 1;        // at insertion point
+            edits.push({ start: { line: e.line, column: startCol2 }, end: { line: e.line, column: endCol2 }, newText: closer });
+          } else {
+            const avail = lineText.slice(caret0);
+            const replaceLen = Math.min(closer.length, Math.max(1, avail.length));
+            edits.push({ start: { line: e.line, column: caret0 + 1 }, end: { line: e.line, column: caret0 + 1 + replaceLen }, newText: closer });
+          }
+        } else {
+          // Generic fallback
+          const avail = lineText.slice(caret0);
+          const replaceLen = Math.min(closer.length, Math.max(1, avail.length));
+          edits.push({ start: { line: e.line, column: caret0 + 1 }, end: { line: e.line, column: caret0 + 1 + replaceLen }, newText: closer });
+        }
       }
       continue;
     }

--- a/src/diagrams/flowchart/parser.ts
+++ b/src/diagrams/flowchart/parser.ts
@@ -240,7 +240,8 @@ export class MermaidParser extends CstParser {
     private linkStyleStatement = this.RULE('linkStyleStatement', () => {
         this.CONSUME(tokens.LinkStyleKeyword);
         this.SUBRULE(this.linkStyleIndexList);
-        this.OPTION1(() => this.CONSUME1(tokens.Newline));
+        // Mermaid CLI expects the style key:value pairs on the SAME line as the indices.
+        // Do not allow a newline between the index list and the first style pair
         this.SUBRULE(this.linkStylePairs);
         this.OPTION2(() => this.CONSUME2(tokens.Newline));
     });

--- a/src/diagrams/flowchart/semantics.ts
+++ b/src/diagrams/flowchart/semantics.ts
@@ -108,7 +108,7 @@ class FlowSemanticsVisitor extends BaseVisitor {
       }
       const fnTok = ch.fn?.[0];
       if (!fnTok) {
-        this.ctx.errors.push({ line: modeTok?.startLine ?? 1, column: modeTok?.startColumn ?? 1, severity: 'error', code: 'FL-CLICK-CALL-NAME-MISSING', message: "'click … call' requires a function name.", hint: 'Example: click A call doThing() "Tooltip"' });
+        this.ctx.errors.push({ line: modeTok?.startLine ?? 1, column: modeTok?.startColumn ?? 1, severity: 'error', code: 'FL-CLICK-CALL-NAME-MISSING', message: "'click … call' requires a function name.", hint: 'Example: click A call doThing()' });
       }
       // Current Mermaid CLI rejects tooltip/target text following call(...)
       const tipTok = ch.tooltip?.[0];
@@ -167,7 +167,7 @@ class FlowSemanticsVisitor extends BaseVisitor {
           severity: 'error',
           code: 'FL-CLICK-CALL-NAME-MISSING',
           message: "'click … call' requires a function name.",
-          hint: 'Example: click A call doThing() "Tooltip"'
+          hint: 'Example: click A call doThing()'
         });
       }
       return;
@@ -315,7 +315,7 @@ class FlowSemanticsVisitor extends BaseVisitor {
               severity: 'error',
               code: 'FL-TYPED-SHAPE-UNKNOWN',
               message: `Unknown shape '${v}' in '@{ shape: … }'.`,
-              hint: 'Use one of: rect, round, stadium, subroutine, circle, cylinder, diamond, trapezoid, parallelogram, hexagon, lean-l, lean-r, icon, image'
+              hint: 'Use one of: rect, rounded, stadium, subroutine, circle, cylinder, diamond, trapezoid, parallelogram, hexagon, "lean-l", "lean-r", icon, image'
             });
           } else {
             // Parity with mermaid-cli: only a subset of typed-shape values are supported today

--- a/test-fixtures/flowchart/INVALID_DIAGRAMS.md
+++ b/test-fixtures/flowchart/INVALID_DIAGRAMS.md
@@ -56,7 +56,7 @@ This file contains invalid flowchart test fixtures with:
 | 9 | [interactions linkstyle ranges](#9-interactions-linkstyle-ranges) | INVALID | INVALID | — |
 | 10 | [invalid arrow](#10-invalid-arrow) | INVALID | INVALID | ✅ safe |
 | 11 | [invalid class](#11-invalid-class) | INVALID | INVALID | — |
-| 12 | [invalid node syntax](#12-invalid-node-syntax) | INVALID | INVALID | ✅ safe |
+| 12 | [invalid node syntax](#12-invalid-node-syntax) | INVALID | INVALID | — |
 | 13 | [invalid subgraph](#13-invalid-subgraph) | INVALID | INVALID | — |
 | 14 | [linkstyle id unknown](#14-linkstyle-id-unknown) | INVALID | INVALID | — |
 | 15 | [missing arrow](#15-missing-arrow) | INVALID | INVALID | ✅ all |
@@ -446,7 +446,7 @@ at test-fixtures/flowchart/invalid/interactions-click-call-missing-fn.mmd:3:11
   3 |   click A call "Tip only"
     |           ^
   4 | 
-hint: Example: click A call doThing() "Tooltip"
+hint: Example: click A call doThing()
 
 error[FL-CLICK-CALL-EXTRA-TEXT]: Tooltip/text after 'call()' is not supported by Mermaid CLI.
 at test-fixtures/flowchart/invalid/interactions-click-call-missing-fn.mmd:3:16
@@ -662,21 +662,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### maid Result: INVALID
 
 ```
-error[FL-LINKSTYLE-INDEX-OUT-OF-RANGE]: linkStyle index 5 is out of range (0..1).
-at test-fixtures/flowchart/invalid/interactions-linkstyle-multi.mmd:5:19
-  4 |   %% indices include duplicate and out-of-range; styles split across lines
+error[FL-LINKSTYLE-MULTILINE]: 'linkStyle' styles must be on the same line as the indices.
+at test-fixtures/flowchart/invalid/interactions-linkstyle-multi.mmd:6:5
   5 |   linkStyle 0, 0, 5
-    |                   ^
   6 |     stroke:#f00,
-hint: Use an index between 0 and 1 or add more links first.
-
-warning[FL-LINKSTYLE-DUPLICATE-INDEX]: Duplicate linkStyle index 0.
-at test-fixtures/flowchart/invalid/interactions-linkstyle-multi.mmd:5:13
-  4 |   %% indices include duplicate and out-of-range; styles split across lines
-  5 |   linkStyle 0, 0, 5
-    |             ^
-  6 |     stroke:#f00,
-hint: Remove duplicates.
+    |     ^
+  7 |     stroke-width:2px
+hint: Example: linkStyle 0,1 stroke:#f00,stroke-width:2px
 ```
 
 ### maid Auto-fix (`--fix`) Preview
@@ -745,12 +737,13 @@ Parser3.parseError (node_modules/mermaid/dist/mermaid.js:91236:28)
 ### maid Result: INVALID
 
 ```
-error: Expecting token of type --> Identifier <-- but found --> ':' <--
+error[FL-LINKSTYLE-RANGE-NOT-SUPPORTED]: Ranges in 'linkStyle' indices are not supported. Use comma-separated indices.
 at test-fixtures/flowchart/invalid/interactions-linkstyle-ranges.mmd:4:14
   3 |   B --> C[End]
   4 |   linkStyle 0:1 stroke:#f00,stroke-width:2px
     |              ^
-  5 |
+  5 | 
+hint: Example: linkStyle 0,1 stroke:#f00,stroke-width:2px
 ```
 
 ### maid Auto-fix (`--fix`) Preview
@@ -959,15 +952,11 @@ hint: Example: A((Circle))
 
 ### maid Auto-fix (`--fix`) Preview
 
-```mermaid
-flowchart TD
-    A(( ))--> B
-    B --> C
-```
+No auto-fix changes (safe level).
 
 ### maid Auto-fix (`--fix=all`) Preview
 
-Shown above (safe changes applied).
+No auto-fix changes (all level).
 
 <details>
 <summary>View source code</summary>
@@ -1804,7 +1793,7 @@ at test-fixtures/flowchart/invalid/typed-shapes-unknowns.mmd:2:14
   2 |   A@{ shape: rhombus, label: "X" }
     |              ^
   3 |   B@{ shape: rect, padding: "ten" }
-hint: Use one of: rect, round, stadium, subroutine, circle, cylinder, diamond, trapezoid, parallelogram, hexagon, lean-l, lean-r, icon, image
+hint: Use one of: rect, rounded, stadium, subroutine, circle, cylinder, diamond, trapezoid, parallelogram, hexagon, "lean-l", "lean-r", icon, image
 
 warning[FL-TYPED-NUMERIC-EXPECTED]: 'padding' expects a number (optionally with px).
 at test-fixtures/flowchart/invalid/typed-shapes-unknowns.mmd:3:29
@@ -1905,7 +1894,7 @@ hint: Example: A[Label] --> B
 
 ```mermaid
 flowchart LR
-    A[Start ]--> B
+    A[Start]--> B
     B --> C
 ```
 

--- a/test-fixtures/flowchart/compat-gaps.json
+++ b/test-fixtures/flowchart/compat-gaps.json
@@ -1,4 +1,16 @@
 {
   "diagramType": "flowchart",
-  "items": []
+  "items": [
+    {
+      "id": "flowchart-linkstyle-multiline",
+      "title": "linkStyle styles split across multiple lines",
+      "status": "maid-accepts-cli-rejects",
+      "example": "test-fixtures/flowchart/invalid/interactions-linkstyle-multi.mmd",
+      "summary": "Maid accepts multiline style declarations (indices on one line; styles on following lines). Current mermaid-cli rejects when styles start on a new line.",
+      "maid": "Parses indices, then style pairs across subsequent lines; validates indices (duplicates/out-of-range).",
+      "mermaid": "Parse error after indices when a newline precedes styles; expects styles on the same line as indices.",
+      "proposedAction": "Align with mermaid-cli (reject multiline) or gate via an option; keep ranges like 0:3 invalid.",
+      "severity": "medium"
+    }
+  ]
 }


### PR DESCRIPTION
- Parser: require linkStyle styles on the same line as indices (FL-LINKSTYLE-MULTILINE)\n- Diagnostics: FL-LINKSTYLE-RANGE-NOT-SUPPORTED for index ranges (0:1)\n- Fixes: square-bracket unclosed fix trims whitespace; double-circle ((… fixed under --fix=all by inferring node id as label (no placeholders)\n- Tests: test-fixes covers double-circle path\n- Docs: errors.md/spec-parity.md updated\n- Previews: flowchart invalid regenerated\n\nNo fixture changes other than regenerated preview markdown. CI expected to be green on tests; previews should be aligned.