### PR TITLE
Flowchart: unmatched 'end' → autofix (remove stray line)

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -21,8 +21,9 @@ This table shows which diagnostics Maid can auto-fix and how. Levels:
 | FL-DIR-MISSING | Safe | Insert default direction ` TD` after header. |
 | FL-DIR-INVALID | None | No change (ambiguous); suggests valid tokens. |
 | FL-DIR-KW-INVALID | Safe | Replace unknown keyword before direction with `direction`. |
-| FL-LINK-MISSING | All | Insert ` --> ` between two nodes on the same line. |
+| FL-LINK-MISSING | All | Insert ` --> ` between two nodes on one line. |
 | FL-META-UNSUPPORTED | All | Remove unsupported meta line (e.g., `title ...`) in flowchart. |
+| FL-END-WITHOUT-SUBGRAPH | All | Remove stray `end` line (no matching `subgraph`). |
 | FL-NODE-UNCLOSED-BRACKET | All | Insert the best-guess closing bracket at caret. |
 | FL-NODE-MIXED-BRACKETS | Safe | Replace mismatched closer with correct one. |
 | FL-NODE-EMPTY | Safe | Remove empty square-bracket shapes (A[""] / A[" "] / A[]) and keep plain node id (A). |
@@ -195,6 +196,13 @@ Tip: quoting inside labels
   - When: A meta header like `title` appears in a flowchart.
   - Message: "'title' is not supported in flowcharts by the current Mermaid CLI."
   - Hint: "Use a Markdown heading above the code block, or draw a labeled node at the top (e.g., T["Dependency Relationship"])."
+
+
+- FL-END-WITHOUT-SUBGRAPH
+  - When: `end` appears without a matching `subgraph`.
+  - Message: "'end' without a matching 'subgraph'."
+  - Hint: "Remove this end or add a subgraph above."
+  - Auto-fix (`--fix=all`): Removes the stray `end` line.
 ## Pie (PI-*)
 
 - PI-LABEL-REQUIRES-QUOTES

--- a/scripts/test-fixes.js
+++ b/scripts/test-fixes.js
@@ -151,6 +151,12 @@ const cases = [
   },
   // Double-in-double auto-fix is intentionally disabled (unsafe). We still validate escaped-quote cases.
   { name: 'PI-QUOTE-UNCLOSED (all)', before: 'pie\n"Dogs : 10\n', afterLevel: 'all' },
+  {
+    name: 'FL-END-WITHOUT-SUBGRAPH (all)',
+    before: 'flowchart TD\n    A-->B\nend\n',
+    after:  'flowchart TD\n    A-->B\n',
+    afterLevel: 'all'
+  },
   // Sequence
   { name: 'SE-MSG-COLON-MISSING', before: 'sequenceDiagram\nA->B hi\n', after: 'sequenceDiagram\nA->B : hi\n' },
   { name: 'SE-NOTE-MALFORMED', before: 'sequenceDiagram\nNote right of A Hello\n', after: 'sequenceDiagram\nNote right of A : Hello\n' },

--- a/src/core/fixes.ts
+++ b/src/core/fixes.ts
@@ -245,6 +245,15 @@ if (is('FL-LABEL-BACKTICK', e)) {
       continue;
     }
 
+    // Flowchart: unmatched 'end' without a subgraph — remove the stray line (all-level fix)
+    if (is('FL-END-WITHOUT-SUBGRAPH', e)) {
+      if (level === 'all') {
+        edits.push({ start: { line: e.line, column: 1 }, end: { line: e.line + 1, column: 1 }, newText: '' });
+      }
+      continue;
+    }
+
+    // Flowchart: unmatched 'end' without a subgraph — remove the stray line (all-level fix)
     // Flowchart: fix inner quotes inside a double-quoted label within shapes ([], (), {}, [[ ]], (( ))).
     if (is('FL-LABEL-DOUBLE-IN-DOUBLE', e)) {
       const lineText = lineTextAt(text, e.line);


### PR DESCRIPTION
Summary
- Add an `--fix=all` autofix for unmatched `end` without a `subgraph` (FL-END-WITHOUT-SUBGRAPH).
- Behavior: removes the stray `end` line. This aligns with common author intent and yields a valid diagram under mermaid-cli.

Changes
- fixes.ts: implement all-level fix for FL-END-WITHOUT-SUBGRAPH.
- docs/errors.md: document autofix in the matrix + Flowchart section.
- tests: added a test-fixes case for the new fix.
- previews: regenerated flowchart invalid previews.

Verification
- `npm run test:errors:flowchart` → green.
- `node scripts/test-fixes.js` → now includes FL-END-WITHOUT-SUBGRAPH (all) and passes.
- Manual: the provided snippet now shows the error, and `--fix=all` removes the trailing `end`; mermaid-cli accepts the fixed output.
