### PR TITLE
fix(flowchart/autofix): handle backticks in quoted labels correctly

### DIFF
--- a/scripts/test-fixes.js
+++ b/scripts/test-fixes.js
@@ -134,11 +134,11 @@ const cases = [
     before: 'flowchart TD\n  D[Mark Parent as Failed (Fatal)]\n',
     after:  'flowchart TD\n  D[Mark Parent as Failed &#40;Fatal&#41;]\n'
   },
-  {
-    name: 'FL-LABEL-CURLY-IN-QUOTED',
-    before: 'flowchart TD\n  A["Append {id}"]\n',
-    after:  'flowchart TD\n  A["Append &#123;id&#125;"]\n'
-  },
+  // FL-LABEL-CURLY-IN-QUOTED is not auto-fixable because:
+  // 1. Curly braces work perfectly in quoted labels
+  // 2. Mermaid doesn't decode numeric HTML entities (&#123;/&#125;)
+  // 3. There's no viable workaround
+  // This error may be outdated and should potentially be downgraded to a warning or removed
   {
     name: 'FL-LABEL-QUOTE-IN-UNQUOTED (parallelogram)',
     before: 'flowchart LR\n  P[/Calls logger.debug("msg")/]\n',

--- a/src/renderer/svg-generator.ts
+++ b/src/renderer/svg-generator.ts
@@ -508,7 +508,12 @@ ${baseGroup}
       .replace(/&gt;/g, '>')
       .replace(/&amp;/g, '&')
       .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'");
+      .replace(/&#39;/g, "'")
+      .replace(/&#96;/g, '`')
+      .replace(/&#123;/g, '{')
+      .replace(/&#125;/g, '}')
+      .replace(/&#40;/g, '(')
+      .replace(/&#41;/g, ')');
   }
 
   private generateEdge(edge: LayoutEdge, padX: number, padY: number, nodeMap: Record<string, {x:number;y:number;width:number;height:number;shape:string}>): { path: string; overlay?: string } {

--- a/test-fixtures/flowchart/INVALID_DIAGRAMS.md
+++ b/test-fixtures/flowchart/INVALID_DIAGRAMS.md
@@ -405,7 +405,7 @@ graph TB
     
     SchemaProcessing -->|No| SkipSchema[Skip schema processing]
     
-    SchemaProcessing -->|Yes| RecursiveCall["Recursive answer() call<br/>with schema prompt:<br/><br/>'CRITICAL: You MUST respond with<br/>ONLY valid JSON DATA that conforms<br/>to this schema structure.<br/>DO NOT return the schema<br/>definition itself.<br/><br/>Schema to follow:<br/>[schema]<br/><br/>REQUIREMENTS:<br/>- Return ONLY the JSON object/array<br/>with REAL DATA<br/>- DO NOT return the schema definition<br/>- NO additional text, explanations,<br/>or markdown formatting<br/>- NO code blocks or backticks<br/>- The JSON must be parseable<br/>- Fill in actual values<br/><br/>EXAMPLE:<br/>If schema defines type object<br/>with properties name, age<br/>Return: &#123;&quot;name&quot;: &quot;John Doe&quot;, &quot;age&quot;: 25&#125;<br/>NOT: &#123;&quot;type&quot;: &quot;object&quot;, &quot;properties&quot;: ...&#125;operties&quot;: ...&#125;...&#125;'<br/><br/>Options: _schemaFormatted = true<br/>lines 1717-1741"]
+    SchemaProcessing -->|Yes| RecursiveCall["Recursive answer() call<br/>with schema prompt:<br/><br/>'CRITICAL: You MUST respond with<br/>ONLY valid JSON DATA that conforms<br/>to this schema structure.<br/>DO NOT return the schema<br/>definition itself.<br/><br/>Schema to follow:<br/>[schema]<br/><br/>REQUIREMENTS:<br/>- Return ONLY the JSON object/array<br/>with REAL DATA<br/>- DO NOT return the schema definition<br/>- NO additional text, explanations,<br/>or markdown formatting<br/>- NO code blocks or backticks<br/>- The JSON must be parseable<br/>- Fill in actual values<br/><br/>EXAMPLE:<br/>If schema defines type object<br/>with properties name, age<br/>Return: {&quot;name&quot;: &quot;John Doe&quot;, &quot;age&quot;: 25}<br/>NOT: {&quot;type&quot;: &quot;object&quot;, &quot;properties&quot;: ...}'<br/><br/>Options: _schemaFormatted = true<br/>lines 1717-1741"]
     
     RecursiveCall --> CleanResponse1[cleanSchemaResponse<br/>Extract JSON from markdown<br/>line 1744]
     
@@ -439,7 +439,7 @@ graph TB
     
     RetryLoop -->|Yes| CallJsonFixer[jsonFixer.fixJson<br/>with enhanced error context<br/>lines 1874-1879]
     
-    CallJsonFixer --> JsonFixerInternal["JsonFixingAgent.fixJson:<br/>Creates specialized prompt<br/>based on retry count<br/><br/>Retry 0:<br/>'CRITICAL JSON ERROR:<br/>Your previous response is not<br/>valid JSON. Error: [error]<br/><br/>Invalid response:<br/>[response preview]<br/><br/>You MUST fix this...'<br/><br/>Retry 1:<br/>'URGENT - JSON PARSING FAILED:<br/>This is your second chance...<br/>Return ONLY valid JSON...'<br/><br/>Retry 2:<br/>'FINAL ATTEMPT - CRITICAL:<br/>This is the final retry...<br/>You MUST return ONLY raw JSON<br/>without any other content.<br/>EXAMPLE: &#123;&quot;key&quot;: &quot;value&quot;&#125;<br/>NOT: &#96;&#96;&#96;json&#123;&quot;key&quot;: &quot;value&quot;&#125;&#96;&#96;&#96;e&quot;&#125;&#96;&#96;&#96;&#125;&#96;&#96;<br/><br/>lines 427-478 in schemaUtils.js"]
+    CallJsonFixer --> JsonFixerInternal["JsonFixingAgent.fixJson:<br/>Creates specialized prompt<br/>based on retry count<br/><br/>Retry 0:<br/>'CRITICAL JSON ERROR:<br/>Your previous response is not<br/>valid JSON. Error: [error]<br/><br/>Invalid response:<br/>[response preview]<br/><br/>You MUST fix this...'<br/><br/>Retry 1:<br/>'URGENT - JSON PARSING FAILED:<br/>This is your second chance...<br/>Return ONLY valid JSON...'<br/><br/>Retry 2:<br/>'FINAL ATTEMPT - CRITICAL:<br/>This is the final retry...<br/>You MUST return ONLY raw JSON<br/>without any other content.<br/>EXAMPLE: {&quot;key&quot;: &quot;value&quot;}<br/>NOT: json{&quot;key&quot;: &quot;value&quot;}'<br/><br/>lines 427-478 in schemaUtils.js"]
     
     JsonFixerInternal --> JsonFixerAnswer["JsonFixingAgent calls<br/>its own answer() with:<br/>- Correction prompt<br/>- disableJsonValidation: true<br/>- _schemaFormatted: true<br/>lines 882-888 in schemaUtils.js"]
     
@@ -479,7 +479,7 @@ graph TB
     
     ValidateAttempt --> CheckSchemaDefAttempt{Schema definition?<br/>line 1986}
     
-    CheckSchemaDefAttempt -->|Yes| SchemaDefPrompt["createSchemaDefinitionCorrectionPrompt:<br/>'CRITICAL MISUNDERSTANDING:<br/>You returned a JSON schema<br/>definition instead of data...<br/><br/>You must return ACTUAL DATA<br/>that follows the schema.<br/><br/>Instead of:<br/>&#123;&quot;type&quot;: &quot;object&quot;,<br/>&quot;properties&quot;: &#123;...&#125;&#125;<br/><br/>Return:<br/>&#123;&quot;actualData&quot;: &quot;value&quot;,<br/>&quot;realField&quot;: 123&#125;ealField&quot;: 123&#125;123&#125;'<br/><br/>lines 1992-2002"]
+    CheckSchemaDefAttempt -->|Yes| SchemaDefPrompt["createSchemaDefinitionCorrectionPrompt:<br/>'CRITICAL MISUNDERSTANDING:<br/>You returned a JSON schema<br/>definition instead of data...<br/><br/>You must return ACTUAL DATA<br/>that follows the schema.<br/><br/>Instead of:<br/>{&quot;type&quot;: &quot;object&quot;,<br/>&quot;properties&quot;: {...}}<br/><br/>Return:<br/>{&quot;actualData&quot;: &quot;value&quot;,<br/>&quot;realField&quot;: 123}'<br/><br/>lines 1992-2002"]
     
     CheckSchemaDefAttempt -->|No| AttemptRetry{Valid?}
     
@@ -758,7 +758,7 @@ hint: Remove the backticks or use quotes instead, e.g., "GITHUB_ACTIONS" and "--
 
 ```mermaid
 flowchart TD
-  A["#96;&#123;% if %&#125;&#96; template"] --> B{Stage}
+  A["{% if %} template"] --> B{Stage}
 
 
 ```


### PR DESCRIPTION
Fixes issue where backticks in quoted labels were being converted to numeric HTML entities which Mermaid doesn't decode, causing them to render as literal text.

## Problem

When a diagram contained backticks in a quoted label:
```mermaid
flowchart TD
  A["`{% if %}` template"] --> B{Stage}
```

The autofix was producing HTML entities that Mermaid doesn't decode:
```mermaid
A["&#96;&#123;% if %&#125;&#96; template"]
```

This rendered as `&`&{%` instead of the intended text.

## Root Cause

The autofix was encoding special characters to numeric HTML entities:
- Backticks → `&#96;`
- Curly braces → `&#123;` / `&#125;`

However, **Mermaid only decodes named HTML entities** like `&quot;`, `&amp;`, not numeric entities like `&#96;`. This caused the entities to render as literal text instead of the actual characters.

## Solution

Since Mermaid doesn't support numeric HTML entities:

1. **Remove backticks entirely** - they're not supported in Mermaid labels
2. **Keep curly braces as-is** - they work perfectly fine in quoted labels  
3. **FL-LABEL-CURLY-IN-QUOTED is now not auto-fixable** - no viable fix exists (the error may need to be downgraded to a warning in the future)

## Changes

- **src/core/fixes.ts**: 
  - Updated `sanitizeQuotedInner()` to remove backticks instead of encoding
  - Removed curly brace encoding (they work fine in quoted labels)
  - FL-LABEL-CURLY-IN-QUOTED handler now skips (no fix possible)
  - FL-LABEL-BACKTICK for unquoted labels (warnings) still removes backticks
- **src/renderer/svg-generator.ts**: Enhanced `htmlDecode()` for internal renderer
  (numeric entity decoding for Maid's own SVG rendering only)
- **scripts/test-fixes.js**: Removed FL-LABEL-CURLY-IN-QUOTED test case (not fixable)
- **test-fixtures/flowchart/INVALID_DIAGRAMS.md**: Regenerated previews

## Test Results

✅ All 79 baseline tests pass  
✅ All 43 autofix tests pass  
✅ User's diagram now renders correctly:
   - Input: `A["\`{% if %}\` template"]`
   - Fixed: `A["{% if %} template"]`  
   - Renders as: `{% if %} template` (clean, no artifacts)

## Before/After Screenshots

**Before (broken):**

The autofix produced `A["&#96;&#123;% if %&#125;&#96; template"]` which rendered as:
- `&`&{% if %}&}& template` (HTML entity artifacts visible as literal text)

**After (correct):**

The autofix produces `A["{% if %} template"]` which renders as:
- `{% if %} template` (clean, readable)

## Technical Details

### Why numeric HTML entities don't work

Mermaid's label rendering only decodes a limited set of **named** HTML entities:
- `&quot;` → `"`
- `&amp;` → `&`
- `&lt;` → `<`
- `&gt;` → `>`
- `&apos;` → `'`

Numeric entities like `&#96;` (backtick), `&#123;` (left brace), `&#125;` (right brace) are **not** decoded and render as literal text.

### Why curly braces don't need fixing

Testing shows that curly braces work perfectly in quoted labels:
```mermaid
flowchart TD
  A["Test {curly}"] --> B["{at start}"]
  C["{}empty"] --> D["multiple {a} and {b}"]
```

All of these render correctly without any special encoding. The FL-LABEL-CURLY-IN-QUOTED error appears to be overly conservative and may need revisiting.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>