### PR TITLE
Update module resolution in maid-mcp

### DIFF
--- a/packages/maid-mcp/tsconfig.json
+++ b/packages/maid-mcp/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
+    "module": "Node16",
     "lib": ["ES2020"],
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "outDir": "./out",
     "rootDir": "./src",
     "declaration": true,


### PR DESCRIPTION
## Background
The `maid-mcp` package was failing to build due to TypeScript module resolution errors when importing from `@probelabs/maid`. This was because the `@probelabs/maid` package uses the `exports` field in its `package.json` to define subpath imports, which the older `moduleResolution: "node"` setting does not support.

## Changes
- **`packages/maid-mcp/tsconfig.json`**:
  - Changed `"module": "ES2020"` to `"module": "Node16"`.
  - Changed `"moduleResolution": "node"` to `"moduleResolution": "node16"`.

This update enables `maid-mcp` to correctly resolve modules that use the `exports` field in their `package.json`, aligning with modern Node.js module resolution strategies.

## Testing
- [ ] Run `npm run build` in the `maid-mcp` package and verify no TypeScript errors.
- [ ] Verify that imports from `@probelabs/maid/core/*` are correctly resolved.
