### PR TITLE
fix(sequence): reject unescaped semicolons in message text

### DIFF
--- a/.github/workflows/visor.yml
+++ b/.github/workflows/visor.yml
@@ -31,15 +31,9 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           installation-id: ${{ secrets.APP_INSTALLATION_ID }}
           auto-review: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request') && 'true' || 'false' }}
-          max-parallelism: '1'
           debug: 'true'
           fail-fast: 'true'
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           # AI Provider API Keys (configure one of these in your repository secrets)
-          # GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.GLM_API_KEY }}
-          ANTHROPIC_API_URL: 'https://api.z.ai/api/anthropic/v1'
-          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          # Optional: Specify the AI model to use
-          MODEL_NAME: 'glm-5'
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}

--- a/.github/workflows/visor.yml
+++ b/.github/workflows/visor.yml
@@ -31,9 +31,15 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           installation-id: ${{ secrets.APP_INSTALLATION_ID }}
           auto-review: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request') && 'true' || 'false' }}
+          max-parallelism: '1'
           debug: 'true'
           fail-fast: 'true'
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           # AI Provider API Keys (configure one of these in your repository secrets)
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          # GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.GLM_API_KEY }}
+          ANTHROPIC_API_URL: 'https://api.z.ai/api/anthropic/v1'
+          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # Optional: Specify the AI model to use
+          MODEL_NAME: 'glm-5'

--- a/scripts/test-fixes.js
+++ b/scripts/test-fixes.js
@@ -238,6 +238,16 @@ const cases = [
   },
   // Sequence
   { name: 'SE-MSG-COLON-MISSING', before: 'sequenceDiagram\nA->B hi\n', after: 'sequenceDiagram\nA->B : hi\n' },
+  {
+    name: 'SE-MSG-SEMICOLON-UNESCAPED',
+    before: 'sequenceDiagram\nparticipant UI\nUI->>UI: Some text; with a semicolon\n',
+    after: 'sequenceDiagram\nparticipant UI\nUI->>UI: Some text#59; with a semicolon\n'
+  },
+  {
+    name: 'SE-MSG-SEMICOLON-ESCAPED',
+    before: 'sequenceDiagram\nparticipant UI\nUI->>UI: Some text#59; with a semicolon\n',
+    after: 'sequenceDiagram\nparticipant UI\nUI->>UI: Some text#59; with a semicolon\n'
+  },
   { name: 'SE-NOTE-MALFORMED', before: 'sequenceDiagram\nNote right of A Hello\n', after: 'sequenceDiagram\nNote right of A : Hello\n' },
   { name: 'SE-NOTE-MALFORMED (multiline header)', before: 'sequenceDiagram\nNote right of A\n  body\nend note\n', after: 'sequenceDiagram\nNote right of A : body\n' },
   {

--- a/src/core/fixes.ts
+++ b/src/core/fixes.ts
@@ -71,6 +71,22 @@ export function computeFixes(text: string, errors: ValidationError[], level: Fix
     out = out.split(SENT_Q).join('&quot;');
     return out;
   }
+
+  function escapeUnescapedSemicolons(textPart: string): string {
+    let out = '';
+    for (let i = 0; i < textPart.length; i++) {
+      const ch = textPart[i];
+      if (ch !== ';') {
+        out += ch;
+        continue;
+      }
+      const upto = textPart.slice(0, i + 1);
+      const isEntity = /(?:#\d+|&#\d+|&[A-Za-z][A-Za-z0-9]+);$/.test(upto);
+      out += isEntity ? ';' : '#59;';
+    }
+    return out;
+  }
+
   for (const e of errors) {
     const key = `${e.code}@${e.line}:${e.column}:${e.length ?? 1}`;
     if (seen.has(key)) continue;
@@ -1086,6 +1102,32 @@ export function computeFixes(text: string, errors: ValidationError[], level: Fix
       } else {
         // Fallback: insert at current caret
         edits.push(insertAt(text, at(e), ': '));
+      }
+      continue;
+    }
+    if (is('SE-MSG-SEMICOLON-UNESCAPED', e)) {
+      const lineText = lineTextAt(text, e.line);
+      const arrows = ['<<-->>', '<<->>', '-->>', '->>', '-->', '->', '--x', '-x', '--)', '-)'];
+      let ai = -1;
+      let alen = 0;
+      for (const a of arrows) {
+        const idx = lineText.indexOf(a);
+        if (idx !== -1 && (ai === -1 || idx < ai)) { ai = idx; alen = a.length; }
+      }
+      if (ai !== -1) {
+        const colonIdx = lineText.indexOf(':', ai + alen);
+        if (colonIdx !== -1) {
+          const head = lineText.slice(0, colonIdx + 1);
+          const tail = lineText.slice(colonIdx + 1);
+          const fixedTail = escapeUnescapedSemicolons(tail);
+          if (fixedTail !== tail) {
+            edits.push({
+              start: { line: e.line, column: 1 },
+              end: { line: e.line, column: lineText.length + 1 },
+              newText: head + fixedTail
+            });
+          }
+        }
       }
       continue;
     }

--- a/src/diagrams/sequence/semantics.ts
+++ b/src/diagrams/sequence/semantics.ts
@@ -14,6 +14,11 @@ class SequenceSemanticsVisitor extends BaseVisitor {
   }
 }
 
+function isEscapedEntitySemicolon(image: string, semicolonIdx: number): boolean {
+  const uptoSemicolon = image.slice(0, semicolonIdx + 1);
+  return /(?:#\d+|&#\d+|&[A-Za-z][A-Za-z0-9]+);$/.test(uptoSemicolon);
+}
+
 export function analyzeSequence(_cst: CstNode, _tokens: IToken[]): ValidationError[] {
   const ctx = { tokens: _tokens };
   const v = new SequenceSemanticsVisitor(ctx);
@@ -113,6 +118,32 @@ export function analyzeSequence(_cst: CstNode, _tokens: IToken[]): ValidationErr
     if (arrowIdx > 0) {
       const from = grabActorRef(arr, 0);
       const to = grabActorRef(arr, arrowIdx+1);
+      const colonIdx = arr.findIndex((tk, idx) => idx > arrowIdx && tk.tokenType === t.Colon);
+      if (colonIdx !== -1) {
+        let semicolonColumn: number | null = null;
+        for (let i = colonIdx + 1; i < arr.length && semicolonColumn == null; i++) {
+          const tk = arr[i];
+          const img = tk.image || '';
+          if (!img.includes(';')) continue;
+          for (let j = 0; j < img.length; j++) {
+            if (img[j] !== ';') continue;
+            if (isEscapedEntitySemicolon(img, j)) continue;
+            semicolonColumn = (tk.startColumn ?? 1) + j;
+            break;
+          }
+        }
+        if (semicolonColumn != null) {
+          errs.push({
+            line: ln,
+            column: semicolonColumn,
+            severity: 'error',
+            code: 'SE-MSG-SEMICOLON-UNESCAPED',
+            message: "Semicolons in sequence message text must be escaped as '#59;'.",
+            hint: "Replace ';' with '#59;' in the message text.",
+            length: 1
+          });
+        }
+      }
       if (from || to) {
         // suffix checks: presence of Plus/Minus tokens on the line
         const plusTok = arr.find(tk => tk.tokenType === t.Plus);

--- a/test-fixtures/sequence/INVALID_DIAGRAMS.md
+++ b/test-fixtures/sequence/INVALID_DIAGRAMS.md
@@ -27,15 +27,16 @@ This file contains invalid sequence test fixtures with:
 16. [Details And Properties](#16-details-and-properties)
 17. [Else In Par Nested](#17-else-in-par-nested)
 18. [Else Outside Alt](#18-else-outside-alt)
-19. [Issue Note Over Multiline Hyphen Alias](#19-issue-note-over-multiline-hyphen-alias)
-20. [Missing Colon](#20-missing-colon)
-21. [Note Malformed](#21-note-malformed)
-22. [Note Multiline Missing Colon](#22-note-multiline-missing-colon)
-23. [Option In Par](#23-option-in-par)
-24. [Option Outside Critical](#24-option-outside-critical)
-25. [Title And Accessibility](#25-title-and-accessibility)
-26. [Unmatched End](#26-unmatched-end)
-27. [Wrong Arrow](#27-wrong-arrow)
+19. [Issue 69 Semicolon In Message](#19-issue-69-semicolon-in-message)
+20. [Issue Note Over Multiline Hyphen Alias](#20-issue-note-over-multiline-hyphen-alias)
+21. [Missing Colon](#21-missing-colon)
+22. [Note Malformed](#22-note-malformed)
+23. [Note Multiline Missing Colon](#23-note-multiline-missing-colon)
+24. [Option In Par](#24-option-in-par)
+25. [Option Outside Critical](#25-option-outside-critical)
+26. [Title And Accessibility](#26-title-and-accessibility)
+27. [Unmatched End](#27-unmatched-end)
+28. [Wrong Arrow](#28-wrong-arrow)
 
 ---
 
@@ -61,15 +62,16 @@ This file contains invalid sequence test fixtures with:
 | 16 | [details and properties](#16-details-and-properties) | INVALID | INVALID | — |
 | 17 | [else in par nested](#17-else-in-par-nested) | INVALID | INVALID | — |
 | 18 | [else outside alt](#18-else-outside-alt) | INVALID | INVALID | — |
-| 19 | [issue note over multiline hyphen alias](#19-issue-note-over-multiline-hyphen-alias) | INVALID | INVALID | ✅ safe |
-| 20 | [missing colon](#20-missing-colon) | INVALID | INVALID | ✅ safe |
-| 21 | [note malformed](#21-note-malformed) | INVALID | INVALID | ✅ safe |
-| 22 | [note multiline missing colon](#22-note-multiline-missing-colon) | INVALID | INVALID | ✅ safe |
-| 23 | [option in par](#23-option-in-par) | INVALID | INVALID | — |
-| 24 | [option outside critical](#24-option-outside-critical) | INVALID | INVALID | — |
-| 25 | [title and accessibility](#25-title-and-accessibility) | INVALID | INVALID | — |
-| 26 | [unmatched end](#26-unmatched-end) | INVALID | INVALID | — |
-| 27 | [wrong arrow](#27-wrong-arrow) | INVALID | INVALID | — |
+| 19 | [issue 69 semicolon in message](#19-issue-69-semicolon-in-message) | INVALID | INVALID | ✅ safe |
+| 20 | [issue note over multiline hyphen alias](#20-issue-note-over-multiline-hyphen-alias) | INVALID | INVALID | ✅ safe |
+| 21 | [missing colon](#21-missing-colon) | INVALID | INVALID | ✅ safe |
+| 22 | [note malformed](#22-note-malformed) | INVALID | INVALID | ✅ safe |
+| 23 | [note multiline missing colon](#23-note-multiline-missing-colon) | INVALID | INVALID | ✅ safe |
+| 24 | [option in par](#24-option-in-par) | INVALID | INVALID | — |
+| 25 | [option outside critical](#25-option-outside-critical) | INVALID | INVALID | — |
+| 26 | [title and accessibility](#26-title-and-accessibility) | INVALID | INVALID | — |
+| 27 | [unmatched end](#27-unmatched-end) | INVALID | INVALID | — |
+| 28 | [wrong arrow](#28-wrong-arrow) | INVALID | INVALID | — |
 
 ---
 
@@ -1645,7 +1647,86 @@ sequenceDiagram
 
 ---
 
-## 19. Issue Note Over Multiline Hyphen Alias
+## 19. Issue 69 Semicolon In Message
+
+📄 **Source**: [`issue-69-semicolon-in-message.mmd`](./invalid/issue-69-semicolon-in-message.mmd)
+
+### GitHub Render Attempt
+
+> **Note**: This invalid diagram may not render or may render incorrectly.
+
+```mermaid
+sequenceDiagram
+    participant UI
+
+    UI->>UI: Some text; with a semicolon
+
+```
+
+### Error Comparison: mermaid-cli vs maid
+
+<table>
+<tr>
+<th width="50%">mermaid-cli</th>
+<th width="50%">maid</th>
+</tr>
+<tr>
+<td valign="top">
+
+**Result**: ❌ INVALID
+
+```
+Syntax error in text
+```
+
+</td>
+<td valign="top">
+
+**Result**: ❌ INVALID
+
+```
+error[SE-MSG-SEMICOLON-UNESCAPED]: Semicolons in sequence message text must be escaped as '#59;'.
+at test-fixtures/sequence/invalid/issue-69-semicolon-in-message.mmd:4:23
+  3 | 
+  4 |     UI->>UI: Some text; with a semicolon
+    |                       ^
+  5 | 
+hint: Replace ';' with '#59;' in the message text.
+```
+
+</td>
+</tr>
+</table>
+
+### maid Auto-fix (`--fix`) Preview
+
+```mermaid
+sequenceDiagram
+    participant UI
+
+    UI->>UI: Some text#59; with a semicolon
+
+```
+
+### maid Auto-fix (`--fix=all`) Preview
+
+Shown above (safe changes applied).
+
+<details>
+<summary>View source code</summary>
+
+```
+sequenceDiagram
+    participant UI
+
+    UI->>UI: Some text; with a semicolon
+
+```
+</details>
+
+---
+
+## 20. Issue Note Over Multiline Hyphen Alias
 
 📄 **Source**: [`issue-note-over-multiline-hyphen-alias.mmd`](./invalid/issue-note-over-multiline-hyphen-alias.mmd)
 
@@ -1782,7 +1863,7 @@ sequenceDiagram
 
 ---
 
-## 20. Missing Colon
+## 21. Missing Colon
 
 📄 **Source**: [`missing-colon.mmd`](./invalid/missing-colon.mmd)
 
@@ -1864,7 +1945,7 @@ sequenceDiagram
 
 ---
 
-## 21. Note Malformed
+## 22. Note Malformed
 
 📄 **Source**: [`note-malformed.mmd`](./invalid/note-malformed.mmd)
 
@@ -1946,7 +2027,7 @@ sequenceDiagram
 
 ---
 
-## 22. Note Multiline Missing Colon
+## 23. Note Multiline Missing Colon
 
 📄 **Source**: [`note-multiline-missing-colon.mmd`](./invalid/note-multiline-missing-colon.mmd)
 
@@ -2048,7 +2129,7 @@ sequenceDiagram
 
 ---
 
-## 23. Option In Par
+## 24. Option In Par
 
 📄 **Source**: [`option-in-par.mmd`](./invalid/option-in-par.mmd)
 
@@ -2131,7 +2212,7 @@ sequenceDiagram
 
 ---
 
-## 24. Option Outside Critical
+## 25. Option Outside Critical
 
 📄 **Source**: [`option-outside-critical.mmd`](./invalid/option-outside-critical.mmd)
 
@@ -2209,7 +2290,7 @@ sequenceDiagram
 
 ---
 
-## 25. Title And Accessibility
+## 26. Title And Accessibility
 
 📄 **Source**: [`title-and-accessibility.mmd`](./invalid/title-and-accessibility.mmd)
 
@@ -2306,7 +2387,7 @@ sequenceDiagram
 
 ---
 
-## 26. Unmatched End
+## 27. Unmatched End
 
 📄 **Source**: [`unmatched-end.mmd`](./invalid/unmatched-end.mmd)
 
@@ -2381,7 +2462,7 @@ sequenceDiagram
 
 ---
 
-## 27. Wrong Arrow
+## 28. Wrong Arrow
 
 📄 **Source**: [`wrong-arrow.mmd`](./invalid/wrong-arrow.mmd)
 

--- a/test-fixtures/sequence/expected-errors.json
+++ b/test-fixtures/sequence/expected-errors.json
@@ -83,5 +83,8 @@
   ],
   "issue-note-over-multiline-hyphen-alias.mmd": [
     "SE-NOTE-MALFORMED"
+  ],
+  "issue-69-semicolon-in-message.mmd": [
+    "SE-MSG-SEMICOLON-UNESCAPED"
   ]
 }

--- a/test-fixtures/sequence/invalid/issue-69-semicolon-in-message.mmd
+++ b/test-fixtures/sequence/invalid/issue-69-semicolon-in-message.mmd
@@ -1,0 +1,4 @@
+sequenceDiagram
+    participant UI
+
+    UI->>UI: Some text; with a semicolon


### PR DESCRIPTION
## Summary
- add sequence semantic validation for unescaped semicolons in message text (`SE-MSG-SEMICOLON-UNESCAPED`)
- add auto-fix to escape semicolons as `#59;` in message bodies
- preserve already escaped entities (no double-escaping)
- add issue fixture and expected error mapping for issue #69
- add fix regression tests for both unescaped and already escaped semicolons

## Testing
- npm run build
- node scripts/test-errors.js sequence
- node scripts/test-fixes.js
- node scripts/compare-linters.js sequence

Closes #69
