### PR TITLE
feat(class): add style, classDef, and cssClass support

### DIFF
--- a/src/diagrams/class/lexer.ts
+++ b/src/diagrams/class/lexer.ts
@@ -16,6 +16,12 @@ export const AsKw = createToken({ name: 'AsKw', pattern: /as/, longer_alt: Ident
 export const NoteKw = createToken({ name: 'NoteKw', pattern: /note/, longer_alt: Identifier });
 export const ForKw = createToken({ name: 'ForKw', pattern: /for/, longer_alt: Identifier });
 
+// Styling keywords (parity with mermaid.js classDiagram spec)
+export const StyleKeyword = createToken({ name: 'StyleKeyword', pattern: /style/, longer_alt: Identifier });
+export const ClassDefKeyword = createToken({ name: 'ClassDefKeyword', pattern: /classDef/, longer_alt: Identifier });
+export const CssClassKeyword = createToken({ name: 'CssClassKeyword', pattern: /cssClass/, longer_alt: Identifier });
+export const ColorValue = createToken({ name: 'ColorValue', pattern: /#[0-9a-fA-F]{3,6}/ });
+
 // Relationship operators (order matters: longest first)
 export const RelCompToAgg = createToken({ name: 'RelCompToAgg', pattern: /\*--o/ });
 export const RelAggToComp = createToken({ name: 'RelAggToComp', pattern: /o--\*/ });
@@ -66,6 +72,9 @@ export const allTokens = [
   TitleKw,
   NamespaceKw,
   InterfaceKw,
+  ClassDefKeyword,
+  CssClassKeyword,
+  StyleKeyword,
   ClassKw,
   AsKw,
   NoteKw,
@@ -96,8 +105,9 @@ export const allTokens = [
   LParen, RParen,
   SquareOpen, SquareClose,
   Colon, Comma,
+  // Atoms (ColorValue before Visibility so #hex isn't split into # + hex)
+  ColorValue,
   Visibility,
-  // Atoms
   NumberLiteral,
   BacktickName,
   Identifier,

--- a/src/diagrams/class/parser.ts
+++ b/src/diagrams/class/parser.ts
@@ -22,6 +22,9 @@ export class ClassParser extends CstParser {
       { ALT: () => this.SUBRULE(this.interfaceLine) },
       { ALT: () => this.SUBRULE(this.relationStmt) },
       { ALT: () => this.SUBRULE(this.noteStmt) },
+      { ALT: () => this.SUBRULE(this.styleStatement) },
+      { ALT: () => this.SUBRULE(this.classDefStatement) },
+      { ALT: () => this.SUBRULE(this.cssClassStatement) },
       { ALT: () => this.SUBRULE(this.memberAssignStmt) },
       { ALT: () => this.CONSUME(t.Newline) },
     ]);
@@ -234,6 +237,46 @@ export class ClassParser extends CstParser {
       { ALT: () => this.CONSUME(t.NumberLiteral) },
     ]);
     this.OPTION2(() => this.CONSUME(t.Newline));
+  });
+
+  // style ClassName fill:#f9f,stroke:#333,color:#fff
+  private styleStatement = this.RULE('styleStatement', () => {
+    this.CONSUME(t.StyleKeyword);
+    this.CONSUME(t.Identifier);
+    this.MANY(() => {
+      this.OR([
+        { ALT: () => this.CONSUME2(t.Identifier) },
+        { ALT: () => this.CONSUME(t.ColorValue) },
+        { ALT: () => this.CONSUME(t.Colon) },
+        { ALT: () => this.CONSUME(t.Comma) },
+        { ALT: () => this.CONSUME(t.NumberLiteral) },
+      ]);
+    });
+    this.OPTION(() => this.CONSUME(t.Newline));
+  });
+
+  // classDef myStyle fill:#f9f,stroke:#333
+  private classDefStatement = this.RULE('classDefStatement', () => {
+    this.CONSUME(t.ClassDefKeyword);
+    this.CONSUME(t.Identifier);
+    this.MANY(() => {
+      this.OR([
+        { ALT: () => this.CONSUME2(t.Identifier) },
+        { ALT: () => this.CONSUME(t.ColorValue) },
+        { ALT: () => this.CONSUME(t.Colon) },
+        { ALT: () => this.CONSUME(t.Comma) },
+        { ALT: () => this.CONSUME(t.NumberLiteral) },
+      ]);
+    });
+    this.OPTION(() => this.CONSUME(t.Newline));
+  });
+
+  // cssClass "ClassName1,ClassName2" myStyle
+  private cssClassStatement = this.RULE('cssClassStatement', () => {
+    this.CONSUME(t.CssClassKeyword);
+    this.CONSUME(t.QuotedString);
+    this.CONSUME(t.Identifier);
+    this.OPTION(() => this.CONSUME(t.Newline));
   });
 
   private relationOp = this.RULE('relationOp', () => {

--- a/test-fixtures/class/VALID_DIAGRAMS.md
+++ b/test-fixtures/class/VALID_DIAGRAMS.md
@@ -27,7 +27,8 @@ This file contains all valid class test fixtures rendered with both Mermaid and 
 12. [relations leftward](#12-relations-leftward)
 13. [simple](#13-simple)
 14. [stereotype and alias](#14-stereotype-and-alias)
-15. [title only](#15-title-only)
+15. [style and classdef](#15-style-and-classdef)
+16. [title only](#16-title-only)
 
 ---
 
@@ -851,7 +852,90 @@ ServiceInterface ..|> Service : implements
 
 ---
 
-## 15. Title Only
+## 15. Style And Classdef
+
+📄 **Source**: [`style-and-classdef.mmd`](./valid/style-and-classdef.mmd)
+
+### Rendered Output
+
+<table>
+<tr>
+<th width="50%">Mermaid (Official)</th>
+<th width="50%">Maid (Experimental)</th>
+</tr>
+<tr>
+<td>
+
+```mermaid
+classDiagram
+    class Animal {
+        +name: string
+        +makeSound()
+    }
+    class Dog {
+        +breed: string
+        +bark()
+    }
+    class Cat {
+        +color: string
+        +meow()
+    }
+
+    Animal <|-- Dog
+    Animal <|-- Cat
+
+    style Animal fill:#1565c0,stroke:#42a5f5,color:#fff
+    style Dog fill:#2e7d32,stroke:#66bb6a,color:#fff
+    style Cat fill:#2e7d32,stroke:#66bb6a,color:#fff
+
+    classDef abstract fill:#e8f4fd,stroke:#2196f3
+    cssClass "Animal" abstract
+
+```
+
+</td>
+<td>
+
+<img src="./rendered/style-and-classdef.svg" alt="Maid Rendered Diagram" />
+
+</td>
+</tr>
+</table>
+
+<details>
+<summary>View source code</summary>
+
+```
+classDiagram
+    class Animal {
+        +name: string
+        +makeSound()
+    }
+    class Dog {
+        +breed: string
+        +bark()
+    }
+    class Cat {
+        +color: string
+        +meow()
+    }
+
+    Animal <|-- Dog
+    Animal <|-- Cat
+
+    style Animal fill:#1565c0,stroke:#42a5f5,color:#fff
+    style Dog fill:#2e7d32,stroke:#66bb6a,color:#fff
+    style Cat fill:#2e7d32,stroke:#66bb6a,color:#fff
+
+    classDef abstract fill:#e8f4fd,stroke:#2196f3
+    cssClass "Animal" abstract
+
+```
+</details>
+
+---
+
+## 16. Title Only
 
 📄 **Source**: [`title-only.mmd`](./valid/title-only.mmd)
 

--- a/test-fixtures/class/rendered/style-and-classdef.svg
+++ b/test-fixtures/class/rendered/style-and-classdef.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="370" height="290" viewBox="-20 -20 370 290">
+<style>
+    .node-shape { fill: #eef0ff; stroke: #3f3f3f; stroke-width: 1px; }
+    .node-label { fill: #333; font-family: Arial, sans-serif; font-size: 14px; }
+    .edge-path { stroke: #555555; stroke-width: 2px; fill: none; }
+    .edge-label-bg { fill: rgba(232,232,232, 0.8); opacity: 0.5; }
+    .edge-label-text { fill: #333; font-family: Arial, sans-serif; font-size: 12px; }
+    .edge-marker { stroke: #555555; }
+    .edge-marker-fill { fill: #555555; }
+
+    /* Basic stroke dash animation used by flowchart link animation presets */
+    @keyframes dash { to { stroke-dashoffset: -1000; } }
+
+    /* Cluster (flowchart + sequence blocks) */
+    .cluster-bg { fill: #ffffde; }
+    .cluster-border { fill: none; stroke: #aaaa33; stroke-width: 1px; }
+    .cluster-title-bg { fill: rgba(255,255,255,0.8); }
+    .cluster-label-text { fill: #333; font-family: Arial, sans-serif; font-size: 12px; }
+
+    /* Notes */
+    .note { fill: #fff5ad; stroke: #aaaa33; stroke-width: 1px; }
+    .note-text { fill: #333; font-family: Arial, sans-serif; font-size: 12px; }
+
+    /* Sequence-specific add-ons (safe for flowcharts too) */
+    .actor-rect { fill: #eaeaea; stroke: #666; stroke-width: 1.5px; }
+    .actor-label { fill: #111; font-family: Arial, sans-serif; font-size: 16px; }
+    .lifeline { stroke: #999; stroke-width: 1px; }
+    .activation { fill: #f4f4f4; stroke: #666; stroke-width: 1px; }
+    .msg-line { stroke: #333; stroke-width: 1.5px; fill: none; }
+    .msg-line.dotted { stroke-dasharray: 2 2; }
+    .msg-line.thick { stroke-width: 3px; }
+    .openhead { fill: none; stroke: #333; stroke-width: 1.5px; }
+    .crosshead path { stroke: #333; stroke-width: 1.5px; }
+    .msg-label { fill: #333; font-family: Arial, sans-serif; font-size: 12px; dominant-baseline: middle; }
+    .msg-label-bg { fill: #ffffff; stroke: #cccccc; stroke-width: 1px; rx: 3; }
+
+    /* State overlays */
+    .lane-divider { stroke: #aaaaaa; stroke-width: 1px; stroke-dasharray: 4 3; }
+    .end-double { stroke: #3f3f3f; stroke-width: 1px; fill: none; }
+  
+    .class-title { font-weight: 600; }
+    .class-divider { stroke: #aaa; stroke-width: 1; }
+    .class-member { font-size: 12px; }
+  </style>
+  <g transform="translate(105,20)">
+    <rect class="node-shape" width="120" height="80" rx="0"/>
+    <text class="node-label class-title" x="60" y="22" text-anchor="middle" dominant-baseline="middle">Animal</text>
+    <line class="class-divider" x1="0" y1="28" x2="120" y2="28"/>
+    <text class="node-label class-member" x="12" y="36" dominant-baseline="hanging">+ :</text>
+    <line class="class-divider" x1="0" y1="52" x2="120" y2="52"/>
+    <text class="node-label class-member" x="12" y="60" dominant-baseline="hanging">+ ( )</text>
+  </g>
+  <g transform="translate(20,150)">
+    <rect class="node-shape" width="120" height="80" rx="0"/>
+    <text class="node-label class-title" x="60" y="22" text-anchor="middle" dominant-baseline="middle">Dog</text>
+    <line class="class-divider" x1="0" y1="28" x2="120" y2="28"/>
+    <text class="node-label class-member" x="12" y="36" dominant-baseline="hanging">+ :</text>
+    <line class="class-divider" x1="0" y1="52" x2="120" y2="52"/>
+    <text class="node-label class-member" x="12" y="60" dominant-baseline="hanging">+ ( )</text>
+  </g>
+  <g transform="translate(190,150)">
+    <rect class="node-shape" width="120" height="80" rx="0"/>
+    <text class="node-label class-title" x="60" y="22" text-anchor="middle" dominant-baseline="middle">Cat</text>
+    <line class="class-divider" x1="0" y1="28" x2="120" y2="28"/>
+    <text class="node-label class-member" x="12" y="36" dominant-baseline="hanging">+ :</text>
+    <line class="class-divider" x1="0" y1="52" x2="120" y2="52"/>
+    <text class="node-label class-member" x="12" y="60" dominant-baseline="hanging">+ ( )</text>
+  </g>
+<polyline class="edge-path edge-path" points="112.6923076923077,100 80,125 80,150" fill="none"/>
+<polyline class="edge-path edge-path" points="217.30769230769232,100 250,125 250,150" fill="none"/>
+</svg>

--- a/test-fixtures/class/valid/style-and-classdef.mmd
+++ b/test-fixtures/class/valid/style-and-classdef.mmd
@@ -1,0 +1,23 @@
+classDiagram
+    class Animal {
+        +name: string
+        +makeSound()
+    }
+    class Dog {
+        +breed: string
+        +bark()
+    }
+    class Cat {
+        +color: string
+        +meow()
+    }
+
+    Animal <|-- Dog
+    Animal <|-- Cat
+
+    style Animal fill:#1565c0,stroke:#42a5f5,color:#fff
+    style Dog fill:#2e7d32,stroke:#66bb6a,color:#fff
+    style Cat fill:#2e7d32,stroke:#66bb6a,color:#fff
+
+    classDef abstract fill:#e8f4fd,stroke:#2196f3
+    cssClass "Animal" abstract


### PR DESCRIPTION
## Summary

- Add `style`, `classDef`, and `cssClass` directive support to the classDiagram parser
- These are valid mermaid.js syntax but were causing false-positive parse errors in maid
- Mirrors the existing flowchart implementation pattern

## Problem

```mermaid
classDiagram
    class Animal {
        +name: string
    }
    class Dog
    Animal <|-- Dog
    style Animal fill:#1565c0,stroke:#42a5f5,color:#fff
```

This valid mermaid.js diagram produces a parse error in maid because the classDiagram parser has no rules for `style`, `classDef`, or `cssClass` statements.

## Changes

**Lexer** (`src/diagrams/class/lexer.ts`):
- Add `StyleKeyword`, `ClassDefKeyword`, `CssClassKeyword`, and `ColorValue` tokens
- Place `ColorValue` before `Visibility` in token order so `#hex` colours are not split into `#` (visibility) + `hex` (identifier)

**Parser** (`src/diagrams/class/parser.ts`):
- Add `styleStatement` rule: `style <classRef> <style-properties>`
- Add `classDefStatement` rule: `classDef <name> <style-properties>`
- Add `cssClassStatement` rule: `cssClass "<classes>" <styleName>`
- Register all three as alternatives in the `statement` rule

**Test fixture** (`test-fixtures/class/valid/style-and-classdef.mmd`):
- Exercises `style`, `classDef`, and `cssClass` in a single diagram

## Test plan

- [x] All 99 existing tests pass (100%)
- [x] All existing valid class fixtures still validate
- [x] All existing invalid class fixtures still fail
- [x] New fixture validates successfully
- [x] Clean `tsc` build with no errors