### PR TITLE
fix(flowchart): handle note blocks and quoted edge labels

### DIFF
--- a/scripts/test-fixes.js
+++ b/scripts/test-fixes.js
@@ -236,6 +236,12 @@ const cases = [
     after:  'flowchart TD\n  subgraph S1["Container"]\n    A --> S1_node["Node"]\n  end\n',
     afterLevel: 'all'
   },
+  {
+    name: 'FL-NOTE-NOT-SUPPORTED (multiline block, all)',
+    before: 'flowchart TD\n  A[Build] --> B[Release]\n\n  note right of B\n    The release job should wait for\n    the dependency guard to finish.\n  endnote\n',
+    after: 'flowchart TD\n  A[Build] --> B[Release]\n\nB -.-> B_note_4["The release job should wait for<br/>the dependency guard to finish."]\n',
+    afterLevel: 'all'
+  },
   // Sequence
   { name: 'SE-MSG-COLON-MISSING', before: 'sequenceDiagram\nA->B hi\n', after: 'sequenceDiagram\nA->B : hi\n' },
   {

--- a/src/core/fixes.ts
+++ b/src/core/fixes.ts
@@ -87,6 +87,49 @@ export function computeFixes(text: string, errors: ValidationError[], level: Fix
     return out;
   }
 
+  function parseFlowchartNoteBlock(textSource: string, startLine: number): {
+    startLine: number;
+    endLine: number;
+    targetId: string;
+    position: 'left' | 'right' | 'over';
+    text: string;
+  } | null {
+    const lines = textSource.split(/\r?\n/);
+    const raw = lines[startLine - 1] || '';
+    const m = /^\s*note\s+(left|right)\s+of\s+([A-Za-z_][A-Za-z0-9_-]*)\s*(?::\s*(.*))?\s*$/i.exec(raw)
+      || /^\s*note\s+over\s+([A-Za-z_][A-Za-z0-9_-]*)(?:\s*,\s*[A-Za-z_][A-Za-z0-9_-]*)?\s*(?::\s*(.*))?\s*$/i.exec(raw);
+    if (!m) return null;
+
+    const isOver = /^note\s+over\b/i.test(raw.trimStart());
+    const position = isOver ? 'over' : String(m[1] || '').toLowerCase() as 'left' | 'right';
+    const targetId = isOver ? String(m[1] || '') : String(m[2] || '');
+    const inlineText = isOver ? String(m[2] || '') : String(m[3] || '');
+    if (!targetId) return null;
+
+    if (inlineText.trim()) {
+      return {
+        startLine,
+        endLine: startLine,
+        targetId,
+        position,
+        text: inlineText.trim()
+      };
+    }
+
+    const body: string[] = [];
+    let endLine = startLine;
+    for (let i = startLine; i < lines.length; i++) {
+      const bodyRaw = lines[i] || '';
+      if (/^\s*end\s*note\s*$/i.test(bodyRaw) || /^\s*endnote\s*$/i.test(bodyRaw)) {
+        endLine = i + 1;
+        break;
+      }
+      body.push(bodyRaw.trim());
+    }
+    const textOut = body.filter(Boolean).join('<br/>').trim();
+    return { startLine, endLine, targetId, position, text: textOut };
+  }
+
   for (const e of errors) {
     const key = `${e.code}@${e.line}:${e.column}:${e.length ?? 1}`;
     if (seen.has(key)) continue;
@@ -107,6 +150,21 @@ export function computeFixes(text: string, errors: ValidationError[], level: Fix
     if (is('FL-LINK-UNSUPPORTED-MARKER', e)) {
       // Remove the unsupported one-sided marker (x/o) from the inline link text
       edits.push(replaceRange(text, at(e), e.length ?? 1, ''));
+      continue;
+    }
+    if (is('FL-NOTE-NOT-SUPPORTED', e)) {
+      if (level !== 'all') continue;
+      const parsed = parseFlowchartNoteBlock(text, e.line);
+      if (!parsed || !parsed.text) continue;
+      const noteIdBase = `${parsed.targetId}_note_${parsed.startLine}`;
+      const noteId = noteIdBase.replace(/[^A-Za-z0-9_]/g, '_');
+      const noteNode = `${noteId}["${parsed.text.replace(/"/g, '&quot;')}"]`;
+      const replacement = parsed.position === 'left'
+        ? `${noteNode} -.-> ${parsed.targetId}`
+        : `${parsed.targetId} -.-> ${noteNode}`;
+      const start = { line: parsed.startLine, column: 1 };
+      const end = { line: parsed.endLine + 1, column: 1 };
+      edits.push({ start, end, newText: `${replacement}\n` });
       continue;
     }
     // Fix quoted edge labels to use pipe syntax

--- a/src/core/fixes.ts
+++ b/src/core/fixes.ts
@@ -1,5 +1,6 @@
 import type { ValidationError, TextEditLC, FixLevel } from './types.js';
 import { insertAt, replaceRange, lineTextAt, inferIndentFromLine } from './edits.js';
+import { findFlowchartNoteBlocks } from '../diagrams/flowchart/note-blocks.js';
 
 // Helpers
 function at(e: ValidationError) { return { line: e.line, column: e.column }; }
@@ -87,47 +88,14 @@ export function computeFixes(text: string, errors: ValidationError[], level: Fix
     return out;
   }
 
-  function parseFlowchartNoteBlock(textSource: string, startLine: number): {
-    startLine: number;
-    endLine: number;
-    targetId: string;
-    position: 'left' | 'right' | 'over';
-    text: string;
-  } | null {
-    const lines = textSource.split(/\r?\n/);
-    const raw = lines[startLine - 1] || '';
-    const m = /^\s*note\s+(left|right)\s+of\s+([A-Za-z_][A-Za-z0-9_-]*)\s*(?::\s*(.*))?\s*$/i.exec(raw)
-      || /^\s*note\s+over\s+([A-Za-z_][A-Za-z0-9_-]*)(?:\s*,\s*[A-Za-z_][A-Za-z0-9_-]*)?\s*(?::\s*(.*))?\s*$/i.exec(raw);
-    if (!m) return null;
-
-    const isOver = /^note\s+over\b/i.test(raw.trimStart());
-    const position = isOver ? 'over' : String(m[1] || '').toLowerCase() as 'left' | 'right';
-    const targetId = isOver ? String(m[1] || '') : String(m[2] || '');
-    const inlineText = isOver ? String(m[2] || '') : String(m[3] || '');
-    if (!targetId) return null;
-
-    if (inlineText.trim()) {
-      return {
-        startLine,
-        endLine: startLine,
-        targetId,
-        position,
-        text: inlineText.trim()
-      };
+  let flowchartNoteBlocksByStartLine: Map<number, ReturnType<typeof findFlowchartNoteBlocks>[number]> | null = null;
+  function getFlowchartNoteBlock(startLine: number) {
+    if (!flowchartNoteBlocksByStartLine) {
+      flowchartNoteBlocksByStartLine = new Map(
+        findFlowchartNoteBlocks(text).map((block) => [block.startLine, block])
+      );
     }
-
-    const body: string[] = [];
-    let endLine = startLine;
-    for (let i = startLine; i < lines.length; i++) {
-      const bodyRaw = lines[i] || '';
-      if (/^\s*end\s*note\s*$/i.test(bodyRaw) || /^\s*endnote\s*$/i.test(bodyRaw)) {
-        endLine = i + 1;
-        break;
-      }
-      body.push(bodyRaw.trim());
-    }
-    const textOut = body.filter(Boolean).join('<br/>').trim();
-    return { startLine, endLine, targetId, position, text: textOut };
+    return flowchartNoteBlocksByStartLine.get(startLine) ?? null;
   }
 
   for (const e of errors) {
@@ -154,7 +122,7 @@ export function computeFixes(text: string, errors: ValidationError[], level: Fix
     }
     if (is('FL-NOTE-NOT-SUPPORTED', e)) {
       if (level !== 'all') continue;
-      const parsed = parseFlowchartNoteBlock(text, e.line);
+      const parsed = getFlowchartNoteBlock(e.line);
       if (!parsed || !parsed.text) continue;
       const noteIdBase = `${parsed.targetId}_note_${parsed.startLine}`;
       const noteId = noteIdBase.replace(/[^A-Za-z0-9_]/g, '_');

--- a/src/diagrams/flowchart/note-blocks.ts
+++ b/src/diagrams/flowchart/note-blocks.ts
@@ -1,0 +1,82 @@
+export type FlowchartNoteBlock = {
+  startLine: number;
+  endLine: number;
+  targetId: string;
+  position: 'left' | 'right' | 'over';
+  text: string;
+  hasInlineBody: boolean;
+};
+
+type NoteHeader = {
+  targetId: string;
+  position: 'left' | 'right' | 'over';
+  inlineText: string;
+};
+
+function parseFlowchartNoteHeader(raw: string): NoteHeader | null {
+  const leftOrRight = /^\s*note\s+(left|right)\s+of\s+([A-Za-z_][A-Za-z0-9_-]*)\s*(?::\s*(.*))?\s*$/i.exec(raw);
+  if (leftOrRight) {
+    return {
+      position: String(leftOrRight[1]).toLowerCase() as 'left' | 'right',
+      targetId: String(leftOrRight[2] || ''),
+      inlineText: String(leftOrRight[3] || '').trim()
+    };
+  }
+
+  const over = /^\s*note\s+over\s+([A-Za-z_][A-Za-z0-9_-]*)(?:\s*,\s*[A-Za-z_][A-Za-z0-9_-]*)?\s*(?::\s*(.*))?\s*$/i.exec(raw);
+  if (over) {
+    return {
+      position: 'over',
+      targetId: String(over[1] || ''),
+      inlineText: String(over[2] || '').trim()
+    };
+  }
+
+  return null;
+}
+
+export function findFlowchartNoteBlocks(text: string): FlowchartNoteBlock[] {
+  const lines = text.split(/\r?\n/);
+  const blocks: FlowchartNoteBlock[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const header = parseFlowchartNoteHeader(lines[i] || '');
+    if (!header || !header.targetId) continue;
+
+    const startLine = i + 1;
+    if (header.inlineText) {
+      blocks.push({
+        startLine,
+        endLine: startLine,
+        targetId: header.targetId,
+        position: header.position,
+        text: header.inlineText,
+        hasInlineBody: true
+      });
+      continue;
+    }
+
+    let endLine = startLine;
+    const body: string[] = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      const bodyRaw = lines[j] || '';
+      if (/^\s*end\s*note\s*$/i.test(bodyRaw) || /^\s*endnote\s*$/i.test(bodyRaw)) {
+        endLine = j + 1;
+        i = j;
+        break;
+      }
+      body.push(bodyRaw.trim());
+    }
+
+    blocks.push({
+      startLine,
+      endLine,
+      targetId: header.targetId,
+      position: header.position,
+      text: endLine > startLine ? body.filter(Boolean).join('<br/>').trim() : '',
+      hasInlineBody: false
+    });
+  }
+
+  return blocks;
+}

--- a/src/diagrams/flowchart/parser.ts
+++ b/src/diagrams/flowchart/parser.ts
@@ -464,26 +464,34 @@ export class MermaidParser extends CstParser {
     
     // Text inside link (between pipes)
     private linkText = this.RULE("linkText", () => {
-        // Align permissiveness with nodeContent so HTML-like tags (e.g., <br/>)
-        // and common punctuation are accepted inside pipe-delimited labels.
-        this.AT_LEAST_ONE(() => {
-            this.OR([
-                { ALT: () => this.CONSUME(tokens.Identifier) },
-                { ALT: () => this.CONSUME(tokens.Text) },
-                { ALT: () => this.CONSUME(tokens.NumberLiteral) },
-                { ALT: () => this.CONSUME(tokens.ColorValue) },
-                // Allow HTML-like angle brackets and slashes for <br/>, <i>, etc.
-                { ALT: () => this.CONSUME(tokens.AngleLess) },
-                { ALT: () => this.CONSUME(tokens.AngleOpen) },
-                { ALT: () => this.CONSUME(tokens.ForwardSlash) },
-                { ALT: () => this.CONSUME(tokens.Backslash) },
-                // Allow common punctuation seen in labels
-                { ALT: () => this.CONSUME(tokens.Comma) },
-                { ALT: () => this.CONSUME(tokens.Colon) },
-                { ALT: () => this.CONSUME(tokens.Ampersand) },
-                { ALT: () => this.CONSUME(tokens.Semicolon) },
-            ]);
-        });
+        this.OR1([
+            // Mermaid accepts a fully quoted string as the entire pipe label.
+            { ALT: () => this.CONSUME(tokens.QuotedString) },
+            {
+                ALT: () => {
+                    // Align permissiveness with nodeContent so HTML-like tags (e.g., <br/>)
+                    // and common punctuation are accepted inside pipe-delimited labels.
+                    this.AT_LEAST_ONE(() => {
+                        this.OR2([
+                            { ALT: () => this.CONSUME(tokens.Identifier) },
+                            { ALT: () => this.CONSUME(tokens.Text) },
+                            { ALT: () => this.CONSUME(tokens.NumberLiteral) },
+                            { ALT: () => this.CONSUME(tokens.ColorValue) },
+                            // Allow HTML-like angle brackets and slashes for <br/>, <i>, etc.
+                            { ALT: () => this.CONSUME(tokens.AngleLess) },
+                            { ALT: () => this.CONSUME(tokens.AngleOpen) },
+                            { ALT: () => this.CONSUME(tokens.ForwardSlash) },
+                            { ALT: () => this.CONSUME(tokens.Backslash) },
+                            // Allow common punctuation seen in labels
+                            { ALT: () => this.CONSUME(tokens.Comma) },
+                            { ALT: () => this.CONSUME(tokens.Colon) },
+                            { ALT: () => this.CONSUME(tokens.Ampersand) },
+                            { ALT: () => this.CONSUME(tokens.Semicolon) },
+                        ]);
+                    });
+                }
+            }
+        ]);
     });
     
     // Inline link text (e.g., in -.text.-> or -- text -->)

--- a/src/diagrams/flowchart/validate.ts
+++ b/src/diagrams/flowchart/validate.ts
@@ -8,6 +8,45 @@ import { coercePos, mapFlowchartParserError } from '../../core/diagnostics.js';
 import { detectDoubleInDouble, detectUnclosedQuotesInText } from '../../core/quoteHygiene.js';
 import { detectEscapedQuotes } from '../../core/quoteHygiene.js';
 
+type FlowchartNoteBlock = {
+  startLine: number;
+  endLine: number;
+  hasInlineBody: boolean;
+};
+
+function findFlowchartNoteBlocks(text: string): FlowchartNoteBlock[] {
+  const lines = text.split(/\r?\n/);
+  const out: FlowchartNoteBlock[] = [];
+  const startRe = /^\s*note\s+(?:(?:left|right)\s+of|over)\s+\S(?:.*)$/i;
+  const endRe = /^\s*end\s*note\s*$/i;
+  const endCompactRe = /^\s*endnote\s*$/i;
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i] || '';
+    if (!startRe.test(raw)) continue;
+    const startLine = i + 1;
+
+    const colonIdx = raw.indexOf(':');
+    if (colonIdx !== -1) {
+      out.push({ startLine, endLine: startLine, hasInlineBody: true });
+      continue;
+    }
+
+    let endLine = startLine;
+    for (let j = i + 1; j < lines.length; j++) {
+      const bodyRaw = lines[j] || '';
+      if (endRe.test(bodyRaw) || endCompactRe.test(bodyRaw)) {
+        endLine = j + 1;
+        i = j;
+        break;
+      }
+    }
+    out.push({ startLine, endLine, hasInlineBody: false });
+  }
+
+  return out;
+}
+
 export function validateFlowchart(text: string, options: ValidateOptions = {}): ValidationError[] {
   return lintWithChevrotain(text, {
     tokenize,
@@ -32,6 +71,28 @@ export function validateFlowchart(text: string, options: ValidateOptions = {}): 
       return errs;
     },
     postParse: (text, tokens, _cst, prevErrors) => {
+      const noteBlocks = findFlowchartNoteBlocks(text);
+      if (noteBlocks.length > 0) {
+        const isInsideNoteBlock = (line: number) => noteBlocks.some((b) => line >= b.startLine && line <= b.endLine);
+        for (let i = prevErrors.length - 1; i >= 0; i--) {
+          const err = prevErrors[i];
+          if (!err || !isInsideNoteBlock(err.line)) continue;
+          if (err.code === 'FL-NOTE-NOT-SUPPORTED' && noteBlocks.some((b) => b.startLine === err.line)) continue;
+          prevErrors.splice(i, 1);
+        }
+        for (const block of noteBlocks) {
+          if (prevErrors.some((e) => e.code === 'FL-NOTE-NOT-SUPPORTED' && e.line === block.startLine)) continue;
+          prevErrors.push({
+            line: block.startLine,
+            column: 1,
+            severity: 'error',
+            code: 'FL-NOTE-NOT-SUPPORTED',
+            message: "'note' syntax is not supported in flowchart/graph diagrams.",
+            hint: "Notes are only available in sequence diagrams. Use a regular node plus a dotted link instead, or convert the block with '--fix=all'.",
+            length: 4
+          });
+        }
+      }
       
       // Flowchart: unsupported meta headers (title)
       {

--- a/src/diagrams/flowchart/validate.ts
+++ b/src/diagrams/flowchart/validate.ts
@@ -7,45 +7,7 @@ import { lintWithChevrotain } from '../../core/pipeline.js';
 import { coercePos, mapFlowchartParserError } from '../../core/diagnostics.js';
 import { detectDoubleInDouble, detectUnclosedQuotesInText } from '../../core/quoteHygiene.js';
 import { detectEscapedQuotes } from '../../core/quoteHygiene.js';
-
-type FlowchartNoteBlock = {
-  startLine: number;
-  endLine: number;
-  hasInlineBody: boolean;
-};
-
-function findFlowchartNoteBlocks(text: string): FlowchartNoteBlock[] {
-  const lines = text.split(/\r?\n/);
-  const out: FlowchartNoteBlock[] = [];
-  const startRe = /^\s*note\s+(?:(?:left|right)\s+of|over)\s+\S(?:.*)$/i;
-  const endRe = /^\s*end\s*note\s*$/i;
-  const endCompactRe = /^\s*endnote\s*$/i;
-
-  for (let i = 0; i < lines.length; i++) {
-    const raw = lines[i] || '';
-    if (!startRe.test(raw)) continue;
-    const startLine = i + 1;
-
-    const colonIdx = raw.indexOf(':');
-    if (colonIdx !== -1) {
-      out.push({ startLine, endLine: startLine, hasInlineBody: true });
-      continue;
-    }
-
-    let endLine = startLine;
-    for (let j = i + 1; j < lines.length; j++) {
-      const bodyRaw = lines[j] || '';
-      if (endRe.test(bodyRaw) || endCompactRe.test(bodyRaw)) {
-        endLine = j + 1;
-        i = j;
-        break;
-      }
-    }
-    out.push({ startLine, endLine, hasInlineBody: false });
-  }
-
-  return out;
-}
+import { findFlowchartNoteBlocks } from './note-blocks.js';
 
 export function validateFlowchart(text: string, options: ValidateOptions = {}): ValidationError[] {
   return lintWithChevrotain(text, {

--- a/test-fixtures/flowchart/INVALID_DIAGRAMS.md
+++ b/test-fixtures/flowchart/INVALID_DIAGRAMS.md
@@ -49,22 +49,23 @@ This file contains invalid flowchart test fixtures with:
 38. [Mixed Quotes In Labels](#38-mixed-quotes-in-labels)
 39. [Model Initialize Call](#39-model-initialize-call)
 40. [No Diagram Type](#40-no-diagram-type)
-41. [Quotes Double Inside Single](#41-quotes-double-inside-single)
-42. [Quotes In Node Labels](#42-quotes-in-node-labels)
-43. [Round Parens Unquoted](#43-round-parens-unquoted)
-44. [Subgraph Id Collision](#44-subgraph-id-collision)
-45. [Title Unsupported](#45-title-unsupported)
-46. [Typed Parallelogram Parens](#46-typed-parallelogram-parens)
-47. [Typed Shapes All](#47-typed-shapes-all)
-48. [Typed Shapes Unknowns](#48-typed-shapes-unknowns)
-49. [Unclosed Bracket](#49-unclosed-bracket)
-50. [Unclosed Quote In Label](#50-unclosed-quote-in-label)
-51. [Unescaped Quotes In Decision](#51-unescaped-quotes-in-decision)
-52. [Unmatched End](#52-unmatched-end)
-53. [Unquoted Label With Quotes](#53-unquoted-label-with-quotes)
-54. [Unquoted Parens In Labels](#54-unquoted-parens-in-labels)
-55. [Unquoted Parens With Backticks](#55-unquoted-parens-with-backticks)
-56. [Wrong Direction](#56-wrong-direction)
+41. [Note Block Endnote](#41-note-block-endnote)
+42. [Quotes Double Inside Single](#42-quotes-double-inside-single)
+43. [Quotes In Node Labels](#43-quotes-in-node-labels)
+44. [Round Parens Unquoted](#44-round-parens-unquoted)
+45. [Subgraph Id Collision](#45-subgraph-id-collision)
+46. [Title Unsupported](#46-title-unsupported)
+47. [Typed Parallelogram Parens](#47-typed-parallelogram-parens)
+48. [Typed Shapes All](#48-typed-shapes-all)
+49. [Typed Shapes Unknowns](#49-typed-shapes-unknowns)
+50. [Unclosed Bracket](#50-unclosed-bracket)
+51. [Unclosed Quote In Label](#51-unclosed-quote-in-label)
+52. [Unescaped Quotes In Decision](#52-unescaped-quotes-in-decision)
+53. [Unmatched End](#53-unmatched-end)
+54. [Unquoted Label With Quotes](#54-unquoted-label-with-quotes)
+55. [Unquoted Parens In Labels](#55-unquoted-parens-in-labels)
+56. [Unquoted Parens With Backticks](#56-unquoted-parens-with-backticks)
+57. [Wrong Direction](#57-wrong-direction)
 
 ---
 
@@ -112,22 +113,23 @@ This file contains invalid flowchart test fixtures with:
 | 38 | [mixed quotes in labels](#38-mixed-quotes-in-labels) | INVALID | INVALID | — |
 | 39 | [model initialize call](#39-model-initialize-call) | INVALID | INVALID | ✅ safe |
 | 40 | [no diagram type](#40-no-diagram-type) | INVALID | INVALID | — |
-| 41 | [quotes double inside single](#41-quotes-double-inside-single) | INVALID | INVALID | ✅ safe |
-| 42 | [quotes in node labels](#42-quotes-in-node-labels) | INVALID | INVALID | ✅ safe |
-| 43 | [round parens unquoted](#43-round-parens-unquoted) | INVALID | INVALID | ✅ safe |
-| 44 | [subgraph id collision](#44-subgraph-id-collision) | INVALID | INVALID | ✅ all |
-| 45 | [title unsupported](#45-title-unsupported) | INVALID | INVALID | ✅ all |
-| 46 | [typed parallelogram parens](#46-typed-parallelogram-parens) | INVALID | INVALID | ✅ safe |
-| 47 | [typed shapes all](#47-typed-shapes-all) | INVALID | INVALID | — |
-| 48 | [typed shapes unknowns](#48-typed-shapes-unknowns) | INVALID | INVALID | — |
-| 49 | [unclosed bracket](#49-unclosed-bracket) | INVALID | INVALID | ✅ safe |
-| 50 | [unclosed quote in label](#50-unclosed-quote-in-label) | INVALID | INVALID | ✅ all |
-| 51 | [unescaped quotes in decision](#51-unescaped-quotes-in-decision) | INVALID | INVALID | ✅ safe |
-| 52 | [unmatched end](#52-unmatched-end) | INVALID | INVALID | — |
-| 53 | [unquoted label with quotes](#53-unquoted-label-with-quotes) | INVALID | INVALID | ✅ safe |
-| 54 | [unquoted parens in labels](#54-unquoted-parens-in-labels) | INVALID | INVALID | ✅ safe |
-| 55 | [unquoted parens with backticks](#55-unquoted-parens-with-backticks) | INVALID | INVALID | ✅ safe |
-| 56 | [wrong direction](#56-wrong-direction) | INVALID | INVALID | — |
+| 41 | [note block endnote](#41-note-block-endnote) | INVALID | INVALID | ✅ all |
+| 42 | [quotes double inside single](#42-quotes-double-inside-single) | INVALID | INVALID | ✅ safe |
+| 43 | [quotes in node labels](#43-quotes-in-node-labels) | INVALID | INVALID | ✅ safe |
+| 44 | [round parens unquoted](#44-round-parens-unquoted) | INVALID | INVALID | ✅ safe |
+| 45 | [subgraph id collision](#45-subgraph-id-collision) | INVALID | INVALID | ✅ all |
+| 46 | [title unsupported](#46-title-unsupported) | INVALID | INVALID | ✅ all |
+| 47 | [typed parallelogram parens](#47-typed-parallelogram-parens) | INVALID | INVALID | ✅ safe |
+| 48 | [typed shapes all](#48-typed-shapes-all) | INVALID | INVALID | — |
+| 49 | [typed shapes unknowns](#49-typed-shapes-unknowns) | INVALID | INVALID | — |
+| 50 | [unclosed bracket](#50-unclosed-bracket) | INVALID | INVALID | ✅ safe |
+| 51 | [unclosed quote in label](#51-unclosed-quote-in-label) | INVALID | INVALID | ✅ all |
+| 52 | [unescaped quotes in decision](#52-unescaped-quotes-in-decision) | INVALID | INVALID | ✅ safe |
+| 53 | [unmatched end](#53-unmatched-end) | INVALID | INVALID | — |
+| 54 | [unquoted label with quotes](#54-unquoted-label-with-quotes) | INVALID | INVALID | ✅ safe |
+| 55 | [unquoted parens in labels](#55-unquoted-parens-in-labels) | INVALID | INVALID | ✅ safe |
+| 56 | [unquoted parens with backticks](#56-unquoted-parens-with-backticks) | INVALID | INVALID | ✅ safe |
+| 57 | [wrong direction](#57-wrong-direction) | INVALID | INVALID | — |
 
 ---
 
@@ -4106,7 +4108,92 @@ B --> C
 
 ---
 
-## 41. Quotes Double Inside Single
+## 41. Note Block Endnote
+
+📄 **Source**: [`note-block-endnote.mmd`](./invalid/note-block-endnote.mmd)
+
+### GitHub Render Attempt
+
+> **Note**: This invalid diagram may not render or may render incorrectly.
+
+```mermaid
+flowchart TD
+  A[Build] --> B[Release]
+
+  note right of B
+    The release job should wait for
+    the dependency guard to finish.
+  endnote
+
+```
+
+### Error Comparison: mermaid-cli vs maid
+
+<table>
+<tr>
+<th width="50%">mermaid-cli</th>
+<th width="50%">maid</th>
+</tr>
+<tr>
+<td valign="top">
+
+**Result**: ❌ INVALID
+
+```
+Syntax error in text
+```
+
+</td>
+<td valign="top">
+
+**Result**: ❌ INVALID
+
+```
+error[FL-NOTE-NOT-SUPPORTED]: 'note' syntax is not supported in flowchart/graph diagrams.
+at test-fixtures/flowchart/invalid/note-block-endnote.mmd:4:3
+  3 | 
+  4 |   note right of B
+    |   ^^^^
+  5 |     The release job should wait for
+hint: Notes are only available in sequence diagrams. Use node labels or HTML comments (%%comment%%) instead.
+```
+
+</td>
+</tr>
+</table>
+
+### maid Auto-fix (`--fix`) Preview
+
+No auto-fix changes (safe level).
+
+### maid Auto-fix (`--fix=all`) Preview
+
+```mermaid
+flowchart TD
+  A[Build] --> B[Release]
+
+B -.-> B_note_4["The release job should wait for<br/>the dependency guard to finish."]
+
+```
+
+<details>
+<summary>View source code</summary>
+
+```
+flowchart TD
+  A[Build] --> B[Release]
+
+  note right of B
+    The release job should wait for
+    the dependency guard to finish.
+  endnote
+
+```
+</details>
+
+---
+
+## 42. Quotes Double Inside Single
 
 📄 **Source**: [`quotes-double-inside-single.mmd`](./invalid/quotes-double-inside-single.mmd)
 
@@ -4182,7 +4269,7 @@ flowchart LR
 
 ---
 
-## 42. Quotes In Node Labels
+## 43. Quotes In Node Labels
 
 📄 **Source**: [`quotes-in-node-labels.mmd`](./invalid/quotes-in-node-labels.mmd)
 
@@ -4346,7 +4433,7 @@ graph TD
 
 ---
 
-## 43. Round Parens Unquoted
+## 44. Round Parens Unquoted
 
 📄 **Source**: [`round-parens-unquoted.mmd`](./invalid/round-parens-unquoted.mmd)
 
@@ -4422,7 +4509,7 @@ flowchart TD
 
 ---
 
-## 44. Subgraph Id Collision
+## 45. Subgraph Id Collision
 
 📄 **Source**: [`subgraph-id-collision.mmd`](./invalid/subgraph-id-collision.mmd)
 
@@ -4519,7 +4606,7 @@ flowchart TD
 
 ---
 
-## 45. Title Unsupported
+## 46. Title Unsupported
 
 📄 **Source**: [`title-unsupported.mmd`](./invalid/title-unsupported.mmd)
 
@@ -4594,7 +4681,7 @@ flowchart TD
 
 ---
 
-## 46. Typed Parallelogram Parens
+## 47. Typed Parallelogram Parens
 
 📄 **Source**: [`typed-parallelogram-parens.mmd`](./invalid/typed-parallelogram-parens.mmd)
 
@@ -4673,7 +4760,7 @@ flowchart TD
 
 ---
 
-## 47. Typed Shapes All
+## 48. Typed Shapes All
 
 📄 **Source**: [`typed-shapes-all.mmd`](./invalid/typed-shapes-all.mmd)
 
@@ -4794,7 +4881,7 @@ flowchart LR
 
 ---
 
-## 48. Typed Shapes Unknowns
+## 49. Typed Shapes Unknowns
 
 📄 **Source**: [`typed-shapes-unknowns.mmd`](./invalid/typed-shapes-unknowns.mmd)
 
@@ -4895,7 +4982,7 @@ flowchart TD
 
 ---
 
-## 49. Unclosed Bracket
+## 50. Unclosed Bracket
 
 📄 **Source**: [`unclosed-bracket.mmd`](./invalid/unclosed-bracket.mmd)
 
@@ -4968,7 +5055,7 @@ flowchart LR
 
 ---
 
-## 50. Unclosed Quote In Label
+## 51. Unclosed Quote In Label
 
 📄 **Source**: [`unclosed-quote-in-label.mmd`](./invalid/unclosed-quote-in-label.mmd)
 
@@ -5047,7 +5134,7 @@ flowchart TD
 
 ---
 
-## 51. Unescaped Quotes In Decision
+## 52. Unescaped Quotes In Decision
 
 📄 **Source**: [`unescaped-quotes-in-decision.mmd`](./invalid/unescaped-quotes-in-decision.mmd)
 
@@ -5126,7 +5213,7 @@ flowchart TD
 
 ---
 
-## 52. Unmatched End
+## 53. Unmatched End
 
 📄 **Source**: [`unmatched-end.mmd`](./invalid/unmatched-end.mmd)
 
@@ -5194,7 +5281,7 @@ flowchart TD
 
 ---
 
-## 53. Unquoted Label With Quotes
+## 54. Unquoted Label With Quotes
 
 📄 **Source**: [`unquoted-label-with-quotes.mmd`](./invalid/unquoted-label-with-quotes.mmd)
 
@@ -5312,7 +5399,7 @@ flowchart TD
 
 ---
 
-## 54. Unquoted Parens In Labels
+## 55. Unquoted Parens In Labels
 
 📄 **Source**: [`unquoted-parens-in-labels.mmd`](./invalid/unquoted-parens-in-labels.mmd)
 
@@ -5448,7 +5535,7 @@ flowchart TD
 
 ---
 
-## 55. Unquoted Parens With Backticks
+## 56. Unquoted Parens With Backticks
 
 📄 **Source**: [`unquoted-parens-with-backticks.mmd`](./invalid/unquoted-parens-with-backticks.mmd)
 
@@ -5530,7 +5617,7 @@ flowchart TD
 
 ---
 
-## 56. Wrong Direction
+## 57. Wrong Direction
 
 📄 **Source**: [`wrong-direction.mmd`](./invalid/wrong-direction.mmd)
 

--- a/test-fixtures/flowchart/VALID_DIAGRAMS.md
+++ b/test-fixtures/flowchart/VALID_DIAGRAMS.md
@@ -26,36 +26,37 @@ This file contains all valid flowchart test fixtures rendered with both Mermaid 
 11. [edge attr id unknown](#11-edge-attr-id-unknown)
 12. [edge attrs animate](#12-edge-attrs-animate)
 13. [edge ids and animation](#13-edge-ids-and-animation)
-14. [empty diagram](#14-empty-diagram)
-15. [frontmatter theme](#15-frontmatter-theme)
-16. [html in labels](#16-html-in-labels)
-17. [interactions linkstyle multi](#17-interactions-linkstyle-multi)
-18. [keywords in labels](#18-keywords-in-labels)
-19. [link styles](#19-link-styles)
-20. [long text](#20-long-text)
-21. [mismatched quotes](#21-mismatched-quotes)
-22. [multidirectional arrows](#22-multidirectional-arrows)
-23. [nested subgraphs lr](#23-nested-subgraphs-lr)
-24. [nested subgraphs](#24-nested-subgraphs)
-25. [node ids special](#25-node-ids-special)
-26. [node to subgraph](#26-node-to-subgraph)
-27. [only nodes](#27-only-nodes)
-28. [quotes single inside double](#28-quotes-single-inside-double)
-29. [simple flow](#29-simple-flow)
-30. [special arrows](#30-special-arrows)
-31. [special chars](#31-special-chars)
-32. [styling classes](#32-styling-classes)
-33. [subgraph nested direction](#33-subgraph-nested-direction)
-34. [subgraph quoted title](#34-subgraph-quoted-title)
-35. [subgraph to node](#35-subgraph-to-node)
-36. [subgraph to subgraph lr](#36-subgraph-to-subgraph-lr)
-37. [subgraph to subgraph](#37-subgraph-to-subgraph)
-38. [subgraphs](#38-subgraphs)
-39. [typed shapes bad units](#39-typed-shapes-bad-units)
-40. [typed shapes basic](#40-typed-shapes-basic)
-41. [undefined node](#41-undefined-node)
-42. [unicode text](#42-unicode-text)
-43. [with text](#43-with-text)
+14. [edge label quoted pipe br backticks](#14-edge-label-quoted-pipe-br-backticks)
+15. [empty diagram](#15-empty-diagram)
+16. [frontmatter theme](#16-frontmatter-theme)
+17. [html in labels](#17-html-in-labels)
+18. [interactions linkstyle multi](#18-interactions-linkstyle-multi)
+19. [keywords in labels](#19-keywords-in-labels)
+20. [link styles](#20-link-styles)
+21. [long text](#21-long-text)
+22. [mismatched quotes](#22-mismatched-quotes)
+23. [multidirectional arrows](#23-multidirectional-arrows)
+24. [nested subgraphs lr](#24-nested-subgraphs-lr)
+25. [nested subgraphs](#25-nested-subgraphs)
+26. [node ids special](#26-node-ids-special)
+27. [node to subgraph](#27-node-to-subgraph)
+28. [only nodes](#28-only-nodes)
+29. [quotes single inside double](#29-quotes-single-inside-double)
+30. [simple flow](#30-simple-flow)
+31. [special arrows](#31-special-arrows)
+32. [special chars](#32-special-chars)
+33. [styling classes](#33-styling-classes)
+34. [subgraph nested direction](#34-subgraph-nested-direction)
+35. [subgraph quoted title](#35-subgraph-quoted-title)
+36. [subgraph to node](#36-subgraph-to-node)
+37. [subgraph to subgraph lr](#37-subgraph-to-subgraph-lr)
+38. [subgraph to subgraph](#38-subgraph-to-subgraph)
+39. [subgraphs](#39-subgraphs)
+40. [typed shapes bad units](#40-typed-shapes-bad-units)
+41. [typed shapes basic](#41-typed-shapes-basic)
+42. [undefined node](#42-undefined-node)
+43. [unicode text](#43-unicode-text)
+44. [with text](#44-with-text)
 
 ---
 
@@ -718,7 +719,50 @@ flowchart TD
 
 ---
 
-## 14. Empty Diagram
+## 14. Edge Label Quoted Pipe Br Backticks
+
+📄 **Source**: [`edge-label-quoted-pipe-br-backticks.mmd`](./valid/edge-label-quoted-pipe-br-backticks.mmd)
+
+### Rendered Output
+
+<table>
+<tr>
+<th width="50%">Mermaid (Official)</th>
+<th width="50%">Maid (Experimental)</th>
+</tr>
+<tr>
+<td>
+
+```mermaid
+graph TD
+  A -->|tags: `goplugin`| B
+  B -->|"tags: `goplugin,ee,fips`<br>env: `GOFIPS140=v1.0.0`"| C
+
+```
+
+</td>
+<td>
+
+<img src="./rendered/edge-label-quoted-pipe-br-backticks.svg" alt="Maid Rendered Diagram" />
+
+</td>
+</tr>
+</table>
+
+<details>
+<summary>View source code</summary>
+
+```
+graph TD
+  A -->|tags: `goplugin`| B
+  B -->|"tags: `goplugin,ee,fips`<br>env: `GOFIPS140=v1.0.0`"| C
+
+```
+</details>
+
+---
+
+## 15. Empty Diagram
 
 📄 **Source**: [`empty-diagram.mmd`](./valid/empty-diagram.mmd)
 
@@ -759,7 +803,7 @@ flowchart TD
 
 ---
 
-## 15. Frontmatter Theme
+## 16. Frontmatter Theme
 
 📄 **Source**: [`frontmatter-theme.mmd`](./valid/frontmatter-theme.mmd)
 
@@ -834,7 +878,7 @@ flowchart TD
 
 ---
 
-## 16. Html In Labels
+## 17. Html In Labels
 
 📄 **Source**: [`html-in-labels.mmd`](./valid/html-in-labels.mmd)
 
@@ -879,7 +923,7 @@ flowchart LR
 
 ---
 
-## 17. Interactions Linkstyle Multi
+## 18. Interactions Linkstyle Multi
 
 📄 **Source**: [`interactions-linkstyle-multi.mmd`](./valid/interactions-linkstyle-multi.mmd)
 
@@ -930,7 +974,7 @@ flowchart TD
 
 ---
 
-## 18. Keywords In Labels
+## 19. Keywords In Labels
 
 📄 **Source**: [`keywords-in-labels.mmd`](./valid/keywords-in-labels.mmd)
 
@@ -997,7 +1041,7 @@ flowchart TD
 
 ---
 
-## 19. Link Styles
+## 20. Link Styles
 
 📄 **Source**: [`link-styles.mmd`](./valid/link-styles.mmd)
 
@@ -1048,7 +1092,7 @@ flowchart LR
 
 ---
 
-## 20. Long Text
+## 21. Long Text
 
 📄 **Source**: [`long-text.mmd`](./valid/long-text.mmd)
 
@@ -1087,7 +1131,7 @@ flowchart TD
 
 ---
 
-## 21. Mismatched Quotes
+## 22. Mismatched Quotes
 
 📄 **Source**: [`mismatched-quotes.mmd`](./valid/mismatched-quotes.mmd)
 
@@ -1132,7 +1176,7 @@ flowchart TD
 
 ---
 
-## 22. Multidirectional Arrows
+## 23. Multidirectional Arrows
 
 📄 **Source**: [`multidirectional-arrows.mmd`](./valid/multidirectional-arrows.mmd)
 
@@ -1175,7 +1219,7 @@ flowchart LR
 
 ---
 
-## 23. Nested Subgraphs Lr
+## 24. Nested Subgraphs Lr
 
 📄 **Source**: [`nested-subgraphs-lr.mmd`](./valid/nested-subgraphs-lr.mmd)
 
@@ -1230,7 +1274,7 @@ flowchart LR
 
 ---
 
-## 24. Nested Subgraphs
+## 25. Nested Subgraphs
 
 📄 **Source**: [`nested-subgraphs.mmd`](./valid/nested-subgraphs.mmd)
 
@@ -1281,7 +1325,7 @@ flowchart TD
 
 ---
 
-## 25. Node Ids Special
+## 26. Node Ids Special
 
 📄 **Source**: [`node-ids-special.mmd`](./valid/node-ids-special.mmd)
 
@@ -1336,7 +1380,7 @@ flowchart TD
 
 ---
 
-## 26. Node To Subgraph
+## 27. Node To Subgraph
 
 📄 **Source**: [`node-to-subgraph.mmd`](./valid/node-to-subgraph.mmd)
 
@@ -1385,7 +1429,7 @@ flowchart TD
 
 ---
 
-## 27. Only Nodes
+## 28. Only Nodes
 
 📄 **Source**: [`only-nodes.mmd`](./valid/only-nodes.mmd)
 
@@ -1428,7 +1472,7 @@ flowchart TD
 
 ---
 
-## 28. Quotes Single Inside Double
+## 29. Quotes Single Inside Double
 
 📄 **Source**: [`quotes-single-inside-double.mmd`](./valid/quotes-single-inside-double.mmd)
 
@@ -1471,7 +1515,7 @@ flowchart LR
 
 ---
 
-## 29. Simple Flow
+## 30. Simple Flow
 
 📄 **Source**: [`simple-flow.mmd`](./valid/simple-flow.mmd)
 
@@ -1510,7 +1554,7 @@ flowchart TD
 
 ---
 
-## 30. Special Arrows
+## 31. Special Arrows
 
 📄 **Source**: [`special-arrows.mmd`](./valid/special-arrows.mmd)
 
@@ -1555,7 +1599,7 @@ flowchart LR
 
 ---
 
-## 31. Special Chars
+## 32. Special Chars
 
 📄 **Source**: [`special-chars.mmd`](./valid/special-chars.mmd)
 
@@ -1598,7 +1642,7 @@ flowchart LR
 
 ---
 
-## 32. Styling Classes
+## 33. Styling Classes
 
 📄 **Source**: [`styling-classes.mmd`](./valid/styling-classes.mmd)
 
@@ -1641,7 +1685,7 @@ flowchart TD
 
 ---
 
-## 33. Subgraph Nested Direction
+## 34. Subgraph Nested Direction
 
 📄 **Source**: [`subgraph-nested-direction.mmd`](./valid/subgraph-nested-direction.mmd)
 
@@ -1698,7 +1742,7 @@ flowchart TD
 
 ---
 
-## 34. Subgraph Quoted Title
+## 35. Subgraph Quoted Title
 
 📄 **Source**: [`subgraph-quoted-title.mmd`](./valid/subgraph-quoted-title.mmd)
 
@@ -1747,7 +1791,7 @@ flowchart TD
 
 ---
 
-## 35. Subgraph To Node
+## 36. Subgraph To Node
 
 📄 **Source**: [`subgraph-to-node.mmd`](./valid/subgraph-to-node.mmd)
 
@@ -1796,7 +1840,7 @@ flowchart TD
 
 ---
 
-## 36. Subgraph To Subgraph Lr
+## 37. Subgraph To Subgraph Lr
 
 📄 **Source**: [`subgraph-to-subgraph-lr.mmd`](./valid/subgraph-to-subgraph-lr.mmd)
 
@@ -1851,7 +1895,7 @@ flowchart LR
 
 ---
 
-## 37. Subgraph To Subgraph
+## 38. Subgraph To Subgraph
 
 📄 **Source**: [`subgraph-to-subgraph.mmd`](./valid/subgraph-to-subgraph.mmd)
 
@@ -1906,7 +1950,7 @@ flowchart TD
 
 ---
 
-## 38. Subgraphs
+## 39. Subgraphs
 
 📄 **Source**: [`subgraphs.mmd`](./valid/subgraphs.mmd)
 
@@ -1957,7 +2001,7 @@ flowchart TD
 
 ---
 
-## 39. Typed Shapes Bad Units
+## 40. Typed Shapes Bad Units
 
 📄 **Source**: [`typed-shapes-bad-units.mmd`](./valid/typed-shapes-bad-units.mmd)
 
@@ -2004,7 +2048,7 @@ flowchart TD
 
 ---
 
-## 40. Typed Shapes Basic
+## 41. Typed Shapes Basic
 
 📄 **Source**: [`typed-shapes-basic.mmd`](./valid/typed-shapes-basic.mmd)
 
@@ -2051,7 +2095,7 @@ flowchart LR
 
 ---
 
-## 41. Undefined Node
+## 42. Undefined Node
 
 📄 **Source**: [`undefined-node.mmd`](./valid/undefined-node.mmd)
 
@@ -2094,7 +2138,7 @@ flowchart TD
 
 ---
 
-## 42. Unicode Text
+## 43. Unicode Text
 
 📄 **Source**: [`unicode-text.mmd`](./valid/unicode-text.mmd)
 
@@ -2141,7 +2185,7 @@ flowchart LR
 
 ---
 
-## 43. With Text
+## 44. With Text
 
 📄 **Source**: [`with-text.mmd`](./valid/with-text.mmd)
 

--- a/test-fixtures/flowchart/expected-errors.json
+++ b/test-fixtures/flowchart/expected-errors.json
@@ -120,5 +120,8 @@
   ],
   "subgraph-id-collision.mmd": [
     "FL-SUBGRAPH-ID-COLLISION"
+  ],
+  "note-block-endnote.mmd": [
+    "FL-NOTE-NOT-SUPPORTED"
   ]
 }

--- a/test-fixtures/flowchart/invalid/note-block-endnote.mmd
+++ b/test-fixtures/flowchart/invalid/note-block-endnote.mmd
@@ -1,0 +1,7 @@
+flowchart TD
+  A[Build] --> B[Release]
+
+  note right of B
+    The release job should wait for
+    the dependency guard to finish.
+  endnote

--- a/test-fixtures/flowchart/rendered/edge-label-quoted-pipe-br-backticks.svg
+++ b/test-fixtures/flowchart/rendered/edge-label-quoted-pipe-br-backticks.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="320" viewBox="0 0 140 320">
+  <rect x="0" y="0" width="140" height="320" fill="#ffffff" />
+  <style>
+    .node-shape { fill: #eef0ff; stroke: #3f3f3f; stroke-width: 1px; }
+    .node-label { fill: #333; font-family: Arial, sans-serif; font-size: 14px; }
+    .edge-path { stroke: #555555; stroke-width: 2px; fill: none; }
+    .edge-label-bg { fill: rgba(232,232,232, 0.8); opacity: 0.5; }
+    .edge-label-text { fill: #333; font-family: Arial, sans-serif; font-size: 12px; }
+    .edge-marker { stroke: #555555; }
+    .edge-marker-fill { fill: #555555; }
+
+    /* Basic stroke dash animation used by flowchart link animation presets */
+    @keyframes dash { to { stroke-dashoffset: -1000; } }
+
+    /* Cluster (flowchart + sequence blocks) */
+    .cluster-bg { fill: #ffffde; }
+    .cluster-border { fill: none; stroke: #aaaa33; stroke-width: 1px; }
+    .cluster-title-bg { fill: rgba(255,255,255,0.8); }
+    .cluster-label-text { fill: #333; font-family: Arial, sans-serif; font-size: 12px; }
+
+    /* Notes */
+    .note { fill: #fff5ad; stroke: #aaaa33; stroke-width: 1px; }
+    .note-text { fill: #333; font-family: Arial, sans-serif; font-size: 12px; }
+
+    /* Sequence-specific add-ons (safe for flowcharts too) */
+    .actor-rect { fill: #eaeaea; stroke: #666; stroke-width: 1.5px; }
+    .actor-label { fill: #111; font-family: Arial, sans-serif; font-size: 16px; }
+    .lifeline { stroke: #999; stroke-width: 1px; }
+    .activation { fill: #f4f4f4; stroke: #666; stroke-width: 1px; }
+    .msg-line { stroke: #333; stroke-width: 1.5px; fill: none; }
+    .msg-line.dotted { stroke-dasharray: 2 2; }
+    .msg-line.thick { stroke-width: 3px; }
+    .openhead { fill: none; stroke: #333; stroke-width: 1.5px; }
+    .crosshead path { stroke: #333; stroke-width: 1.5px; }
+    .msg-label { fill: #333; font-family: Arial, sans-serif; font-size: 12px; dominant-baseline: middle; }
+    .msg-label-bg { fill: #ffffff; stroke: #cccccc; stroke-width: 1px; rx: 3; }
+
+    /* State overlays */
+    .lane-divider { stroke: #aaaaaa; stroke-width: 1px; stroke-dasharray: 4 3; }
+    .end-double { stroke: #3f3f3f; stroke-width: 1px; fill: none; }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 11 11" markerWidth="11" markerHeight="11" refX="11" refY="6" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M0,0 L0,11 L11,6 z" fill="#555555" />
+    </marker>
+    <marker id="circle-marker" viewBox="0 0 9 9" markerWidth="9" markerHeight="9" refX="4.5" refY="4.5" orient="auto" markerUnits="userSpaceOnUse">
+      <circle cx="4.5" cy="4.5" r="4.5" fill="#555555" />
+    </marker>
+    <marker id="cross-marker" viewBox="0 0 12 12" markerWidth="12" markerHeight="12" refX="6" refY="6" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M1.5,1.5 L10.5,10.5 M10.5,1.5 L1.5,10.5" stroke="#555555" stroke-width="2.25" />
+    </marker>
+  </defs>
+  <g id="A">
+    <rect class="node-shape"  x="40" y="40" width="80" height="40" rx="0" ry="0" />
+    
+    <text class="node-label" x="80" y="64.9" text-anchor="middle">A</text>
+  </g>
+  <g id="B">
+    <rect class="node-shape"  x="40" y="150" width="80" height="40" rx="0" ry="0" />
+    
+    <text class="node-label" x="80" y="174.9" text-anchor="middle">B</text>
+  </g>
+  <g id="C">
+    <rect class="node-shape"  x="40" y="260" width="80" height="40" rx="0" ry="0" />
+    
+    <text class="node-label" x="80" y="284.9" text-anchor="middle">C</text>
+  </g>
+  <g>
+    <path class="edge-path" d="M80,80 L80,90 C80,102 80,134 80,140 L80,150" stroke-linecap="round" stroke-linejoin="round" />
+    <rect class="edge-label-bg" x="25" y="111.5" width="110" height="14" rx="3" />
+    <text class="edge-label-text" x="80" y="118.5" text-anchor="middle" dominant-baseline="middle">tags : `goplugin`</text>
+    <path d="M80,150 L77.5,144 L82.5,144 Z" fill="#555555" />
+  </g>
+  <g>
+    <path class="edge-path" d="M80,190 L80,200 C80,212 80,244 80,250 L80,260" stroke-linecap="round" stroke-linejoin="round" />
+    <rect class="edge-label-bg" x="-30" y="221.5" width="220" height="14" rx="3" />
+    <text class="edge-label-text" x="80" y="228.5" text-anchor="middle" dominant-baseline="middle">tags: `goplugin,ee,fips`&lt;br&gt;env: `GOFIPS140=v1.0.0`</text>
+    <path d="M80,260 L77.5,254 L82.5,254 Z" fill="#555555" />
+  </g>
+  
+</svg>

--- a/test-fixtures/flowchart/valid/edge-label-quoted-pipe-br-backticks.mmd
+++ b/test-fixtures/flowchart/valid/edge-label-quoted-pipe-br-backticks.mmd
@@ -1,0 +1,3 @@
+graph TD
+  A -->|tags: `goplugin`| B
+  B -->|"tags: `goplugin,ee,fips`<br>env: `GOFIPS140=v1.0.0`"| C


### PR DESCRIPTION
## What
- collapse unsupported flowchart `note ... endnote` blocks into a single `FL-NOTE-NOT-SUPPORTED` diagnostic
- allow Mermaid-valid fully quoted pipe edge labels such as `|"tags: ... <br> ..."|`
- keep mixed-content quote usage inside pipe labels rejected as `FL-EDGE-LABEL-QUOTE-IN-PIPES`
- regenerate flowchart previews for the new fixture coverage

## Verification
- npm run build
- node scripts/test-errors.js flowchart
- node scripts/test-fixes.js
- node scripts/compare-linters.js flowchart
- npm run ci:previews